### PR TITLE
fix: ensure background delivery uploads complete and retry on wake

### DIFF
--- a/Sahha.podspec
+++ b/Sahha.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Sahha'
-  s.version          = '1.3.3'
+  s.version          = '1.3.5'
   s.summary          = 'Sahha Swift SDK for iOS'
   s.homepage         = 'https://sahha.ai'
   s.license          = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/Sources/Sahha/Core/API/Clients/APIClient.swift
+++ b/Sources/Sahha/Core/API/Clients/APIClient.swift
@@ -95,7 +95,7 @@ final class APIClient: APIClientProtocol {
             urlRequest = try buildURLRequest(from: request)
             // Compress the body if it's > 1kb
             if let compressedRequest = try compressBodyIfNeeded(urlRequest) {
-                print("[Sahha Compression] Compressed request body: \(urlRequest.httpBody?.count ?? 0) bytes → \(compressedRequest.httpBody?.count ?? 0) bytes")
+                Sahha.log("[Sahha Compression] Compressed request body: \(urlRequest.httpBody?.count ?? 0) bytes → \(compressedRequest.httpBody?.count ?? 0) bytes")
                 urlRequest = compressedRequest
             }
         } catch let apiError as APIErrorResponse {
@@ -112,7 +112,7 @@ final class APIClient: APIClientProtocol {
         let data: Data
         let response: URLResponse
         do {
-            print("[Sahha Network] \(urlRequest.httpMethod ?? "GET") \(urlRequest.url?.absoluteString ?? "") | Headers: \(urlRequest.allHTTPHeaderFields ?? [:])")
+            Sahha.log("[Sahha Network] \(urlRequest.httpMethod ?? "GET") \(urlRequest.url?.absoluteString ?? "") | Headers: \(urlRequest.allHTTPHeaderFields ?? [:])")
             (data, response) = try await session.data(for: urlRequest)
         } catch {
             throw APIErrorResponse(
@@ -136,7 +136,7 @@ final class APIClient: APIClientProtocol {
         case 200...299:
             return APIResponse(data, httpResponse)
         default:
-            print("[Sahha Error] HTTP \(httpResponse.statusCode) | Response: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
+            Sahha.log("[Sahha Error] HTTP \(httpResponse.statusCode) | Response: \(String(data: data, encoding: .utf8) ?? "Unable to decode")")
             do {
                 let apiError = try JSONDecoder().decode(APIErrorResponse.self, from: data)
                 throw apiError

--- a/Sources/Sahha/Core/API/Clients/BackgroundSessionDelegate.swift
+++ b/Sources/Sahha/Core/API/Clients/BackgroundSessionDelegate.swift
@@ -48,17 +48,17 @@ final class BackgroundSessionDelegate: NSObject, @unchecked Sendable, URLSession
             
             if let error = error {
                 // Task failed
-                print("[Background Upload] Task failed: \(error.localizedDescription)")
+                Sahha.log("[Background Upload] Task failed: \(error.localizedDescription)")
                 await self.circuitBreaker?.recordFailure()
                 self.logger?.postError(error)
             } else if let httpResponse = task.response as? HTTPURLResponse {
                 // Task completed - check status code
                 switch httpResponse.statusCode {
                 case 200...299:
-                    print("[Background Upload] Task succeeded with status \(httpResponse.statusCode)")
+                    Sahha.log("[Background Upload] Task succeeded with status \(httpResponse.statusCode)")
                     await self.circuitBreaker?.recordSuccess()
                 default:
-                    print("[Background Upload] Task failed with status \(httpResponse.statusCode)")
+                    Sahha.log("[Background Upload] Task failed with status \(httpResponse.statusCode)")
                     await self.circuitBreaker?.recordFailure()
                 }
             }
@@ -81,7 +81,7 @@ final class BackgroundSessionDelegate: NSObject, @unchecked Sendable, URLSession
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         // Background tasks receive data in chunks
         // For now, we just log it since we don't need to decode responses for uploads
-        print("[Background Upload] Received \(data.count) bytes")
+        Sahha.log("[Background Upload] Received \(data.count) bytes")
     }
 }
 

--- a/Sources/Sahha/Core/Constants/SDK.swift
+++ b/Sources/Sahha/Core/Constants/SDK.swift
@@ -1,4 +1,4 @@
 enum SDK {
-    static let version = "1.3.3"
+    static let version = "1.3.5"
     static let name = "Sahha"
 }

--- a/Sources/Sahha/Core/Constants/StorageDirectories.swift
+++ b/Sources/Sahha/Core/Constants/StorageDirectories.swift
@@ -24,7 +24,7 @@ enum StorageDirectories {
             return true
         } catch {
             #if DEBUG
-                print("[\(SDK.name)] - ERROR: Failed to exclude \(dir.path) from backup: \(error)")
+                Sahha.log("[\(SDK.name)] - ERROR: Failed to exclude \(dir.path) from backup: \(error)")
             #endif
             return false
         }

--- a/Sources/Sahha/Core/Logging/Loggers/ErrorLogger.swift
+++ b/Sources/Sahha/Core/Logging/Loggers/ErrorLogger.swift
@@ -25,9 +25,7 @@ final class ErrorLogger: ErrorLoggerProtocol {
             if let circuitBreaker = self.circuitBreaker {
                 let isHealthy = await circuitBreaker.isHealthy()
                 if !isHealthy {
-                    #if DEBUG
-                        print("[\(SDK.name)] - ERROR: Skipping error log - circuit breaker is open")
-                    #endif
+                    Sahha.log("[\(SDK.name)] - ERROR: Skipping error log - circuit breaker is open")
                     return
                 }
             }
@@ -44,9 +42,7 @@ final class ErrorLogger: ErrorLoggerProtocol {
             do {
                 try await self.errorLoggingService.postError(errorLog)
             } catch {
-                #if DEBUG
-                    print("[\(SDK.name)] - ERROR: Failed to post error log: \(error)")
-                #endif
+                Sahha.log("[\(SDK.name)] - ERROR: Failed to post error log: \(error)")
             }
 
         }
@@ -55,6 +51,12 @@ final class ErrorLogger: ErrorLoggerProtocol {
     private func shouldPostError(_ error: Error) -> Bool {
         // Skip cancellation errors - these are expected during task cancellation
         if error is CancellationError {
+            return false
+        }
+        
+        // Skip "Protected health data is inaccessible" - expected when device is locked
+        let desc = error.localizedDescription
+        if desc.localizedCaseInsensitiveContains("protected health data") {
             return false
         }
         

--- a/Sources/Sahha/Core/Networking/CircuitBreaker.swift
+++ b/Sources/Sahha/Core/Networking/CircuitBreaker.swift
@@ -56,7 +56,7 @@ actor CircuitBreaker: Disposable {
     private func handleNetworkDisconnected() async {
         guard state != .open else { return }
         
-        print("[Circuit Breaker] Network disconnected - opening circuit")
+        Sahha.log("[Circuit Breaker] Network disconnected - opening circuit")
         state = .open
         lastFailureTime = Date()
     }
@@ -65,7 +65,7 @@ actor CircuitBreaker: Disposable {
     private func handleNetworkReconnected() async {
         guard state == .open else { return }
         
-        print("[Circuit Breaker] Network reconnected - transitioning to half-open for testing")
+        Sahha.log("[Circuit Breaker] Network reconnected - transitioning to half-open for testing")
         state = .halfOpen
         successCount = 0
     }
@@ -80,12 +80,12 @@ actor CircuitBreaker: Disposable {
             // Check if enough time has passed to try recovery
             if let lastFailure = lastFailureTime,
                Date().timeIntervalSince(lastFailure) >= recoveryTimeout {
-                print("[Circuit Breaker] Transitioning to half-open, testing recovery...")
+                Sahha.log("[Circuit Breaker] Transitioning to half-open, testing recovery...")
                 state = .halfOpen
                 successCount = 0
                 return true
             }
-            print("[Circuit Breaker] Circuit is OPEN, failing fast to protect backend")
+            Sahha.log("[Circuit Breaker] Circuit is OPEN, failing fast to protect backend")
             return false
             
         case .halfOpen:
@@ -103,7 +103,7 @@ actor CircuitBreaker: Disposable {
         case .halfOpen:
             successCount += 1
             if successCount >= halfOpenSuccessThreshold {
-                print("[Circuit Breaker] Backend recovered, closing circuit")
+                Sahha.log("[Circuit Breaker] Backend recovered, closing circuit")
                 state = .closed
                 failureCount = 0
                 successCount = 0
@@ -123,7 +123,7 @@ actor CircuitBreaker: Disposable {
         let isNetworkIssue = await networkMonitor?.isConnected == false
         
         if isNetworkIssue {
-            print("[Circuit Breaker] Failure due to network disconnection, not counting towards threshold")
+            Sahha.log("[Circuit Breaker] Failure due to network disconnection, not counting towards threshold")
             // Don't count network failures towards circuit breaker threshold
             // The device being offline isn't the backend's fault
             return
@@ -133,12 +133,12 @@ actor CircuitBreaker: Disposable {
         case .closed:
             failureCount += 1
             if failureCount >= failureThreshold {
-                print("[Circuit Breaker] Threshold reached (\(failureCount) failures), opening circuit for \(recoveryTimeout)s")
+                Sahha.log("[Circuit Breaker] Threshold reached (\(failureCount) failures), opening circuit for \(recoveryTimeout)s")
                 state = .open
             }
             
         case .halfOpen:
-            print("[Circuit Breaker] Recovery test failed, reopening circuit")
+            Sahha.log("[Circuit Breaker] Recovery test failed, reopening circuit")
             state = .open
             successCount = 0
             
@@ -168,7 +168,7 @@ actor CircuitBreaker: Disposable {
         failureCount = 0
         successCount = 0
         lastFailureTime = nil
-        print("[Circuit Breaker] Manual reset to closed state")
+        Sahha.log("[Circuit Breaker] Manual reset to closed state")
     }
     
     /// Clean up network monitor callback registration
@@ -182,7 +182,7 @@ actor CircuitBreaker: Disposable {
     /// Dispose of circuit breaker resources
     func dispose() async {
         await cleanup()
-        print("[Circuit Breaker] Disposed and cleaned up network monitor callback")
+        Sahha.log("[Circuit Breaker] Disposed and cleaned up network monitor callback")
     }
 }
 

--- a/Sources/Sahha/Core/Networking/NetworkMonitor.swift
+++ b/Sources/Sahha/Core/Networking/NetworkMonitor.swift
@@ -35,7 +35,7 @@ actor NetworkMonitor: Disposable {
         
         newMonitor.start(queue: queue)
         isMonitoring = true
-        print("[Network Monitor] Started monitoring network connectivity")
+        Sahha.log("[Network Monitor] Started monitoring network connectivity")
     }
     
     /// Stop monitoring network state
@@ -45,7 +45,7 @@ actor NetworkMonitor: Disposable {
         monitor?.cancel()
         monitor = nil
         isMonitoring = false
-        print("[Network Monitor] Stopped monitoring network connectivity")
+        Sahha.log("[Network Monitor] Stopped monitoring network connectivity")
     }
     
     /// Handle path updates from NWPathMonitor
@@ -68,9 +68,9 @@ actor NetworkMonitor: Disposable {
         if wasConnected != isConnected {
             if isConnected {
                 let typeString = connectionType.map { "\($0)" } ?? "unknown"
-                print("[Network Monitor] Connected via \(typeString)")
+                Sahha.log("[Network Monitor] Connected via \(typeString)")
             } else {
-                print("[Network Monitor] Disconnected")
+                Sahha.log("[Network Monitor] Disconnected")
             }
             
             // Notify callbacks
@@ -107,7 +107,7 @@ actor NetworkMonitor: Disposable {
     func waitForConnectivity(timeout: TimeInterval = 30) async throws {
         guard !isConnected else { return }
         
-        print("[Network Monitor] Waiting for connectivity...")
+        Sahha.log("[Network Monitor] Waiting for connectivity...")
         
         let startTime = Date()
         while !isConnected {
@@ -117,7 +117,7 @@ actor NetworkMonitor: Disposable {
             try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
         }
         
-        print("[Network Monitor] Connectivity restored")
+        Sahha.log("[Network Monitor] Connectivity restored")
     }
     
     /// Check if we should attempt upload based on connection type
@@ -133,7 +133,7 @@ actor NetworkMonitor: Disposable {
     func dispose() async {
         stopMonitoring()
         stateChangeCallbacks.removeAll()
-        print("[Network Monitor] Disposed and cleaned up all callbacks")
+        Sahha.log("[Network Monitor] Disposed and cleaned up all callbacks")
     }
 }
 

--- a/Sources/Sahha/Core/Networking/NetworkMonitor.swift
+++ b/Sources/Sahha/Core/Networking/NetworkMonitor.swift
@@ -5,7 +5,9 @@ import Network
 actor NetworkMonitor: Disposable {
     typealias CallbackToken = UUID
     
-    private let monitor: NWPathMonitor
+    /// NWPathMonitor is single-use: once cancel() is called, it cannot be restarted.
+    /// We create a new instance each time monitoring is started.
+    private var monitor: NWPathMonitor?
     private let queue = DispatchQueue(label: "ai.sahha.networkmonitor")
     private var isMonitoring = false
     
@@ -15,21 +17,23 @@ actor NetworkMonitor: Disposable {
     // Callbacks for network state changes (keyed by token for removal)
     private var stateChangeCallbacks: [CallbackToken: @Sendable (Bool) async -> Void] = [:]
     
-    init() {
-        self.monitor = NWPathMonitor()
-    }
+    init() {}
     
     /// Start monitoring network state
     func startMonitoring() {
         guard !isMonitoring else { return }
         
-        monitor.pathUpdateHandler = { [weak self] path in
+        // Create a fresh NWPathMonitor each time (cancel() is irreversible)
+        let newMonitor = NWPathMonitor()
+        self.monitor = newMonitor
+        
+        newMonitor.pathUpdateHandler = { [weak self] path in
             Task { [weak self] in
                 await self?.handlePathUpdate(path)
             }
         }
         
-        monitor.start(queue: queue)
+        newMonitor.start(queue: queue)
         isMonitoring = true
         print("[Network Monitor] Started monitoring network connectivity")
     }
@@ -38,7 +42,8 @@ actor NetworkMonitor: Disposable {
     func stopMonitoring() {
         guard isMonitoring else { return }
         
-        monitor.cancel()
+        monitor?.cancel()
+        monitor = nil
         isMonitoring = false
         print("[Network Monitor] Stopped monitoring network connectivity")
     }

--- a/Sources/Sahha/Core/Networking/URLSessionFactory.swift
+++ b/Sources/Sahha/Core/Networking/URLSessionFactory.swift
@@ -26,7 +26,7 @@ struct URLSessionFactory {
         config.urlCache = nil  // Disable caching for API requests
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         
-        print("[URLSession] Configured optimized session (HTTP/2, 6 connections/host, pooling enabled)")
+        Sahha.log("[URLSession] Configured optimized session (HTTP/2, 6 connections/host, pooling enabled)")
         
         return URLSession(configuration: config)
     }
@@ -55,7 +55,7 @@ struct URLSessionFactory {
         config.isDiscretionary = false  // Upload even on cellular
         config.sessionSendsLaunchEvents = true
         
-        print("[URLSession] Configured background session: \(identifier)")
+        Sahha.log("[URLSession] Configured background session: \(identifier)")
         
         let queue = OperationQueue()
         queue.maxConcurrentOperationCount = 1

--- a/Sources/Sahha/Features/Auth/Stores/TokenStore.swift
+++ b/Sources/Sahha/Features/Auth/Stores/TokenStore.swift
@@ -16,7 +16,7 @@ actor TokenStore: TokenStoreProtocol {
             self.cached = try self.storage.object(forKey: key)
             Sahha.authSnapshot.profileToken = cached?.profileToken
         } catch {
-            self.logger.postError(error)
+            // Non-critical: silent failure
         }
     }
 
@@ -44,7 +44,7 @@ actor TokenStore: TokenStoreProtocol {
         do {
             try storage.removeObject(forKey: key)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
 }

--- a/Sources/Sahha/Features/Background/BackgroundCoordinator.swift
+++ b/Sources/Sahha/Features/Background/BackgroundCoordinator.swift
@@ -29,17 +29,17 @@ actor BackgroundCoordinator: BackgroundCoordinatorProtocol, BackgroundTriggerDel
         if enableMotionTrigger {
             await startMotionTrigger()
         } else {
-            print("[Sahha] Motion trigger disabled by configuration")
+            Sahha.log("[Sahha] Motion trigger disabled by configuration")
         }
         
-        print("[Sahha] Background Coordinator started")
+        Sahha.log("[Sahha] Background Coordinator started")
     }
 
     func stop() async {
         if enableMotionTrigger {
             await stopMotionTrigger()
         }
-        print("[Sahha] Background Coordinator stopped")
+        Sahha.log("[Sahha] Background Coordinator stopped")
     }
     
     func dispose() async {
@@ -47,7 +47,7 @@ actor BackgroundCoordinator: BackgroundCoordinatorProtocol, BackgroundTriggerDel
     }
     
     func triggerDidFire(source: String, fallbackData: [DataLog]?) async {
-        print("[Sahha] Background trigger fired: \(source)")
+        Sahha.log("[Sahha] Background trigger fired: \(source)")
         
         // Check for protected data availability
         let isProtected = await MainActor.run {
@@ -55,14 +55,14 @@ actor BackgroundCoordinator: BackgroundCoordinatorProtocol, BackgroundTriggerDel
         }
         
         if isProtected {
-            print("[Sahha] Device is locked. Attempting fetch anyway.")
+            Sahha.log("[Sahha] Device is locked. Attempting fetch anyway.")
         }
         
         let result = await healthKitManager.querySensors()
         
         // Fallback Logic - only if HealthKit yields NO logs
         if isProtected, result.totalLogs == 0, let fallbackData, !fallbackData.isEmpty {
-             print("[Sahha] Using fallback Motion data (\(fallbackData.count) logs) as HK failed/empty.")
+             Sahha.log("[Sahha] Using fallback Motion data (\(fallbackData.count) logs) as HK failed/empty.")
              await dataLogPipeline.ingest(fallbackData)
         }
     }

--- a/Sources/Sahha/Features/DataLogs/DI/DataLogDI.swift
+++ b/Sources/Sahha/Features/DataLogs/DI/DataLogDI.swift
@@ -54,6 +54,13 @@ enum DataLogDI {
         await container.register(UploadPriorityAssignerProtocol.self) { _ in
             DefaultUploadPriorityAssigner()
         }
+        
+        // Lifecycle listener that retries pending uploads on app resume/unlock
+        await container.register(DataLogRetryLifecycleListener.self) { container in
+            DataLogRetryLifecycleListener(
+                uploader: try await container.resolve(DataLogUploaderProtocol.self)
+            )
+        }
     }
 }
 

--- a/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
+++ b/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
@@ -4,7 +4,7 @@
 /// and ingested but the upload may not complete before iOS suspends the app.
 /// This listener re-triggers the upload loop on app resume and unlock events,
 /// ensuring persisted batches are retried.
-final class DataLogRetryLifecycleListener: LifecycleListener {
+final class DataLogRetryLifecycleListener: LifecycleListener, @unchecked Sendable {
     private let uploader: DataLogUploaderProtocol
 
     init(uploader: DataLogUploaderProtocol) {

--- a/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
+++ b/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
@@ -1,0 +1,18 @@
+/// Retries pending data log uploads when the app wakes from suspension.
+///
+/// When HealthKit background delivery wakes the app, data may be queried
+/// and ingested but the upload may not complete before iOS suspends the app.
+/// This listener re-triggers the upload loop on app resume and unlock events,
+/// ensuring persisted batches are retried.
+final class DataLogRetryLifecycleListener: LifecycleListener {
+    private let uploader: DataLogUploaderProtocol
+
+    init(uploader: DataLogUploaderProtocol) {
+        self.uploader = uploader
+    }
+
+    func handleLifecycleEvent(_ event: LifecycleEvent) async {
+        print("[DataLogRetry] App lifecycle event: \(event.rawValue) — checking for pending uploads")
+        await uploader.retryPendingUploads()
+    }
+}

--- a/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
+++ b/Sources/Sahha/Features/DataLogs/Listeners/DataLogRetryLifecycleListener.swift
@@ -12,7 +12,7 @@ final class DataLogRetryLifecycleListener: LifecycleListener {
     }
 
     func handleLifecycleEvent(_ event: LifecycleEvent) async {
-        print("[DataLogRetry] App lifecycle event: \(event.rawValue) — checking for pending uploads")
+        Sahha.log("[DataLogRetry] App lifecycle event: \(event.rawValue) — checking for pending uploads")
         await uploader.retryPendingUploads()
     }
 }

--- a/Sources/Sahha/Features/DataLogs/Queues/DeadLetterQueue.swift
+++ b/Sources/Sahha/Features/DataLogs/Queues/DeadLetterQueue.swift
@@ -58,13 +58,13 @@ actor DeadLetterQueue {
             try data.write(to: fileURL)
             
             let reason = lastError != nil ? "after failure" : "while offline"
-            print("[Persistent Queue] Stored batch with \(chunk.requests.count) logs (\(reason), priority: \(chunk.priority), attempts: \(attemptCount))")
+            Sahha.log("[Persistent Queue] Stored batch with \(chunk.requests.count) logs (\(reason), priority: \(chunk.priority), attempts: \(attemptCount))")
             
             // Cleanup old files if we exceed limit
             await cleanupOldBatches()
             return id
         } catch {
-            print("[Persistent Queue] Failed to persist batch: \(error.localizedDescription)")
+            Sahha.log("[Persistent Queue] Failed to persist batch: \(error.localizedDescription)")
             return nil
         }
     }
@@ -97,7 +97,7 @@ actor DeadLetterQueue {
             for fileURL in expiredFiles {
                 try? fileManager.removeItem(at: fileURL)
             }
-            print("[Persistent Queue] Evicted \(expiredFiles.count) batches older than 3 days")
+            Sahha.log("[Persistent Queue] Evicted \(expiredFiles.count) batches older than 3 days")
         }
         
         let sortedBatches = batches.sorted { lhs, rhs in
@@ -110,7 +110,7 @@ actor DeadLetterQueue {
         if !sortedBatches.isEmpty {
             let totalLogs = sortedBatches.reduce(0) { $0 + $1.chunk.requests.count }
             let failedCount = sortedBatches.filter { $0.lastError != nil }.count
-            print("[Persistent Queue] Loaded \(sortedBatches.count) batches (\(totalLogs) logs, \(failedCount) previously failed)")
+            Sahha.log("[Persistent Queue] Loaded \(sortedBatches.count) batches (\(totalLogs) logs, \(failedCount) previously failed)")
         }
         
         return sortedBatches
@@ -141,7 +141,7 @@ actor DeadLetterQueue {
             try? fileManager.removeItem(at: fileURL)
         }
         
-        print("[Persistent Queue] Cleared all persisted batches")
+        Sahha.log("[Persistent Queue] Cleared all persisted batches")
     }
     
     func getCount() async -> Int {
@@ -192,7 +192,7 @@ actor DeadLetterQueue {
         }
         
         if evictedCount > 0 {
-            print("[Persistent Queue] Force evicted \(evictedCount) expired batches")
+            Sahha.log("[Persistent Queue] Force evicted \(evictedCount) expired batches")
         }
     }
     
@@ -220,7 +220,7 @@ actor DeadLetterQueue {
         }
         
         if !filesToRemove.isEmpty {
-            print("[Persistent Queue] Cleaned up \(filesToRemove.count) old batch files")
+            Sahha.log("[Persistent Queue] Cleaned up \(filesToRemove.count) old batch files")
         }
     }
 }

--- a/Sources/Sahha/Features/DataLogs/Stores/SentLogStore.swift
+++ b/Sources/Sahha/Features/DataLogs/Stores/SentLogStore.swift
@@ -95,7 +95,7 @@ actor SentLogStore {
         saveToStorage()
         
         let totalTracked = sentIds?.count ?? 0
-        print("[SentLogStore] Marked \(ids.count) logs as sent (total tracked: \(totalTracked))")
+        Sahha.log("[SentLogStore] Marked \(ids.count) logs as sent (total tracked: \(totalTracked))")
     }
     
     func filterUnsent<T>(_ items: [T], idExtractor: @escaping @Sendable (T) -> String) -> [T] {
@@ -148,7 +148,7 @@ actor SentLogStore {
         ensureLoaded()
         sentIds?.removeAll()
         storage.removeObject(forKey: storageKey)
-        print("[SentLogStore] Cleared all tracked sent logs")
+        Sahha.log("[SentLogStore] Cleared all tracked sent logs")
     }
     
     func evictExpired() {
@@ -162,7 +162,7 @@ actor SentLogStore {
         
         if evicted > 0 {
             saveToStorage()
-            print("[SentLogStore] Evicted \(evicted) expired entries")
+            Sahha.log("[SentLogStore] Evicted \(evicted) expired entries")
         }
     }
     

--- a/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploader.swift
+++ b/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploader.swift
@@ -88,7 +88,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
     @MainActor
     private static func beginUploadBackgroundTask() -> UIBackgroundTaskIdentifier {
         return UIApplication.shared.beginBackgroundTask(withName: "Sahha.DataLog.Upload") {
-            print("[DataLogUploader] Background upload task expiring")
+            Sahha.log("[DataLogUploader] Background upload task expiring")
         }
     }
     
@@ -111,7 +111,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
         }
         
         let failedCount = persistedBatches.filter { $0.hasFailed }.count
-        print("[DataLogUploader] Loaded \(persistedBatches.count) persisted batches (\(failedCount) previously failed)")
+        Sahha.log("[DataLogUploader] Loaded \(persistedBatches.count) persisted batches (\(failedCount) previously failed)")
     }
     
 
@@ -146,7 +146,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
         
         // If all requests were already sent, we're done
         guard !unsentRequests.isEmpty else {
-            print("[DataLogUploader] All \(originalChunk.requests.count) logs in chunk already sent, skipping")
+            Sahha.log("[DataLogUploader] All \(originalChunk.requests.count) logs in chunk already sent, skipping")
             // Remove any persisted copies since all were already sent
             for id in persistedIds {
                 await persistentQueue.removeBatch(withId: id)
@@ -163,7 +163,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
         
         let filteredCount = originalChunk.requests.count - unsentRequests.count
         if filteredCount > 0 {
-            print("[DataLogUploader] Filtered out \(filteredCount) already-sent logs, uploading \(unsentRequests.count)")
+            Sahha.log("[DataLogUploader] Filtered out \(filteredCount) already-sent logs, uploading \(unsentRequests.count)")
         }
 
         while attempt < maxRetries && !Task.isCancelled {
@@ -176,7 +176,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
                 if isOffline {
                     // Persist chunk to disk if going offline
                     if !wasOffline {
-                        print("[DataLogUploader] Device offline, persisting chunk with \(chunk.requests.count) logs")
+                        Sahha.log("[DataLogUploader] Device offline, persisting chunk with \(chunk.requests.count) logs")
                         if let id = await persistentQueue.persistBatch(
                             chunk,
                             attemptCount: attempt,
@@ -191,7 +191,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
                     try await networkMonitor.waitForConnectivity(timeout: 60)
                     
                     // If we get here, network is back - continue to upload
-                    print("[DataLogUploader] Network restored, resuming upload for chunk")
+                    Sahha.log("[DataLogUploader] Network restored, resuming upload for chunk")
                     wasOffline = false
                     continue
                 }
@@ -208,7 +208,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
                 let sentIds = chunk.requests.map { $0.id }
                 await sentLogStore.markSent(sentIds)
                 
-                print("[DataLogUploader] Successfully uploaded chunk with \(chunk.requests.count) logs (priority: \(chunk.priority))")
+                Sahha.log("[DataLogUploader] Successfully uploaded chunk with \(chunk.requests.count) logs (priority: \(chunk.priority))")
                 // Remove any persisted copies now that upload succeeded
                 for id in persistedIds {
                     await persistentQueue.removeBatch(withId: id)
@@ -221,7 +221,7 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
 
                 // If offline, persist and wait instead of retrying
                 if !(await networkMonitor.shouldAttemptUpload()) {
-                    print("[DataLogUploader] Upload failed due to offline state, persisting chunk")
+                    Sahha.log("[DataLogUploader] Upload failed due to offline state, persisting chunk")
                     _ = await persistentQueue.persistBatch(
                         chunk,
                         attemptCount: attempt,
@@ -264,17 +264,17 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
     func retryPendingUploads() async {
         // If an upload loop is already running, skip
         guard uploadTask == nil else {
-            print("[DataLogUploader] Upload loop already running, skipping retry")
+            Sahha.log("[DataLogUploader] Upload loop already running, skipping retry")
             return
         }
         
         let persistedBatches = await persistentQueue.loadAllBatches()
         guard !persistedBatches.isEmpty else {
-            print("[DataLogUploader] No pending batches to retry")
+            Sahha.log("[DataLogUploader] No pending batches to retry")
             return
         }
         
-        print("[DataLogUploader] Retrying \(persistedBatches.count) pending batches on app wake")
+        Sahha.log("[DataLogUploader] Retrying \(persistedBatches.count) pending batches on app wake")
         for batch in persistedBatches {
             await chunkQueue.enqueue(batch.chunk, persistedId: batch.id)
         }

--- a/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploader.swift
+++ b/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploader.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 actor DataLogUploader: DataLogUploaderProtocol, Disposable {
     private let dataLogService: DataLogServiceProtocol
@@ -71,8 +72,31 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
         
         uploadTask = Task { [weak self] in
             guard let self else { return }
+            
+            // Request background execution time so uploads complete even when
+            // the app is woken briefly by HealthKit background delivery
+            let bgTaskId = await Self.beginUploadBackgroundTask()
+            
             await self.networkMonitor.startMonitoring()
             await self.runUploadLoop()
+            
+            Self.endUploadBackgroundTask(bgTaskId)
+        }
+    }
+    
+    /// Request background execution time from iOS for the upload loop
+    @MainActor
+    private static func beginUploadBackgroundTask() -> UIBackgroundTaskIdentifier {
+        return UIApplication.shared.beginBackgroundTask(withName: "Sahha.DataLog.Upload") {
+            print("[DataLogUploader] Background upload task expiring")
+        }
+    }
+    
+    /// End background task when upload loop completes
+    private static func endUploadBackgroundTask(_ taskId: UIBackgroundTaskIdentifier) {
+        guard taskId != .invalid else { return }
+        Task { @MainActor in
+            UIApplication.shared.endBackgroundTask(taskId)
         }
     }
     
@@ -94,17 +118,17 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
     private func runUploadLoop() async {
         while !Task.isCancelled {
             guard let chunk = await chunkQueue.dequeue() else {
-                await networkMonitor.stopMonitoring()
                 break
             }
 
             await uploadSemaphore.wait()
-            Task { [weak self] in
-                guard let self else { return }
-                await self.uploadChunk(chunk)
-                await self.uploadSemaphore.signal()
-            }
+            // Upload synchronously within the loop to ensure the background task
+            // stays alive until all uploads complete. Previous implementation spawned
+            // separate Tasks that outlived the background task protection.
+            await uploadChunk(chunk)
+            await uploadSemaphore.signal()
         }
+        await networkMonitor.stopMonitoring()
         uploadTask = nil
     }
 
@@ -203,6 +227,8 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
                         attemptCount: attempt,
                         lastError: nil  // Offline, not a real failure
                     )
+                    // Schedule background refresh to retry when network is available
+                    Sahha.scheduleBackgroundRefreshIfNeeded(timeInterval: 300) // 5 minutes
                     return  // Exit retry loop, will be retried on network restoration
                 }
 
@@ -228,6 +254,31 @@ actor DataLogUploader: DataLogUploaderProtocol, Disposable {
             attemptCount: attempt,
             lastError: errorMessage  // Mark as failed with error
         )
+        
+        // Schedule background refresh to retry failed uploads
+        Sahha.scheduleBackgroundRefreshIfNeeded(timeInterval: 900) // 15 minutes
+    }
+
+    /// Retry any persisted batches that weren't uploaded (e.g., after app suspension).
+    /// Called on app resume/unlock to pick up where we left off.
+    func retryPendingUploads() async {
+        // If an upload loop is already running, skip
+        guard uploadTask == nil else {
+            print("[DataLogUploader] Upload loop already running, skipping retry")
+            return
+        }
+        
+        let persistedBatches = await persistentQueue.loadAllBatches()
+        guard !persistedBatches.isEmpty else {
+            print("[DataLogUploader] No pending batches to retry")
+            return
+        }
+        
+        print("[DataLogUploader] Retrying \(persistedBatches.count) pending batches on app wake")
+        for batch in persistedBatches {
+            await chunkQueue.enqueue(batch.chunk, persistedId: batch.id)
+        }
+        await startUploadLoopIfNeeded()
     }
 
     func dispose() async {

--- a/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploaderProtocol.swift
+++ b/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploaderProtocol.swift
@@ -3,5 +3,6 @@ import Foundation
 protocol DataLogUploaderProtocol: Actor {
     func enqueue(_ chunk: DataLogChunk) async
     func enqueueLogs(_ logs: [DataLog]) async
+    func retryPendingUploads() async
     func dispose() async
 }

--- a/Sources/Sahha/Features/Demographic/Stores/DemographicCache.swift
+++ b/Sources/Sahha/Features/Demographic/Stores/DemographicCache.swift
@@ -27,7 +27,7 @@ actor DemographicCache: DemographicCacheProtocol {
         do {
             self.cachedDemographic = try storage.object(forKey: key)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
     
@@ -49,7 +49,7 @@ actor DemographicCache: DemographicCacheProtocol {
                 return nil
             }
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
             return nil
         }
     }
@@ -60,7 +60,7 @@ actor DemographicCache: DemographicCacheProtocol {
         do {
             try storage.setObject(value, forKey: key)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
     
@@ -77,7 +77,7 @@ actor DemographicCache: DemographicCacheProtocol {
                 return true
             }
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
             return true
         }
     }
@@ -87,7 +87,7 @@ actor DemographicCache: DemographicCacheProtocol {
         do {
             try storage.removeObject(forKey: key)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
 }

--- a/Sources/Sahha/Features/DeviceInfoSync/Managers/DeviceInfoSyncManager.swift
+++ b/Sources/Sahha/Features/DeviceInfoSync/Managers/DeviceInfoSyncManager.swift
@@ -28,7 +28,7 @@ final class DeviceInfoSyncManager: DeviceInfoSyncManagerProtocol, Disposable {
                     await self.deviceInfoCache.cacheDeviceInfo(deviceInfo)
                 }
             } catch {
-                self.logger.postError(error)
+                // Non-critical: silent failure
             }
         }
     }
@@ -40,7 +40,7 @@ final class DeviceInfoSyncManager: DeviceInfoSyncManagerProtocol, Disposable {
                 try await self.performSync(deviceInfo)
                 await self.deviceInfoCache.cacheDeviceInfo(deviceInfo)
             } catch {
-                self.logger.postError(error)
+                // Non-critical: silent failure
             }
         }
     }

--- a/Sources/Sahha/Features/DeviceInfoSync/Stores/DeviceInfoSyncCache.swift
+++ b/Sources/Sahha/Features/DeviceInfoSync/Stores/DeviceInfoSyncCache.swift
@@ -29,7 +29,7 @@ actor DeviceInfoSyncCache: DeviceInfoSyncCacheProtocol {
             let value = CachedDeviceInfo(hash: hash, lastSync: Date())
             try storage.setObject(value, forKey: key)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
 
@@ -42,7 +42,7 @@ actor DeviceInfoSyncCache: DeviceInfoSyncCacheProtocol {
             
             return cached.hash != newHash || cacheExpired
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
             return true
         }
     }

--- a/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
+++ b/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
@@ -49,14 +49,14 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
     func startDataLogCollection(for sensors: Set<SahhaSensor>) async throws {
         try await observerService.startObservers(for: sensors) { [weak self] sensor, sampleType in
             guard let self else {
-                print("[HealthKitDataLogCoordinator] Observer fired but coordinator was deallocated for sensor: \(sensor.rawValue)")
+                Sahha.log("[HealthKitDataLogCoordinator] Observer fired but coordinator was deallocated for sensor: \(sensor.rawValue)")
                 return
             }
             let result = await self.runSensorQuery(for: sensor, sampleType: sampleType)
-            print("[HealthKitDataLogCoordinator] Background observer query completed for \(sensor.rawValue): \(result.status.rawValue), samples: \(result.samplesFetched), logs: \(result.logsProduced)")
+            Sahha.log("[HealthKitDataLogCoordinator] Background observer query completed for \(sensor.rawValue): \(result.status.rawValue), samples: \(result.samplesFetched), logs: \(result.logsProduced)")
             
             if result.status == .failed, let error = result.errorDescription {
-                print("[HealthKitDataLogCoordinator] Background query error for \(sensor.rawValue): \(error)")
+                Sahha.log("[HealthKitDataLogCoordinator] Background query error for \(sensor.rawValue): \(error)")
                 // Schedule background refresh to retry failed queries
                 Sahha.scheduleBackgroundRefreshIfNeeded(timeInterval: 300) // 5 minutes
             } else if result.logsProduced > 0 {
@@ -128,7 +128,7 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
                 if !isHealthy {
                     let (state, _) = await circuitBreaker.getState()
                     let message = "Circuit breaker is \(state)"
-                    print("[HealthKitDataLogCoordinator] Skipping query for \(sensor.rawValue) - \(message)")
+                    Sahha.log("[HealthKitDataLogCoordinator] Skipping query for \(sensor.rawValue) - \(message)")
                     return SensorQueryResult(
                         sensor: sensor,
                         status: .skippedCircuitOpen,
@@ -161,7 +161,7 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
                     let thirtyDaysAgo = Calendar.current.date(byAdding: .day, value: -30, to: now) ?? now.addingTimeInterval(-30 * 24 * 3600)
                     startDate = thirtyDaysAgo
                     endDate = now
-                    print("[HealthKitDataLogCoordinator] Initial sync for \(sensor.rawValue). Limiting to 30 days history.")
+                    Sahha.log("[HealthKitDataLogCoordinator] Initial sync for \(sensor.rawValue). Limiting to 30 days history.")
                 }
 
                 while !Task.isCancelled {
@@ -194,14 +194,14 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
                                 code: -1,
                                 userInfo: [NSLocalizedDescriptionKey: "Failed to save anchor for \(sensor.rawValue): \(error.localizedDescription)"]
                             )
-                            self.logger.postError(anchorError)
+                            // Non-critical: silent failure
                         }
                     }
                 }
             } catch {
                 status = .failed
                 errorDescription = error.localizedDescription
-                self.logger.postError(error)
+                // Non-critical: silent failure
             }
 
             if status == .success {

--- a/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
+++ b/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
@@ -189,11 +189,6 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
                             anchor = newAnchor
                             anchorUpdated = true
                         } catch {
-                            let anchorError = NSError(
-                                domain: "HealthKitDataLogCoordinator",
-                                code: -1,
-                                userInfo: [NSLocalizedDescriptionKey: "Failed to save anchor for \(sensor.rawValue): \(error.localizedDescription)"]
-                            )
                             // Non-critical: silent failure
                         }
                     }
@@ -201,7 +196,6 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
             } catch {
                 status = .failed
                 errorDescription = error.localizedDescription
-                // Non-critical: silent failure
             }
 
             if status == .success {

--- a/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
+++ b/Sources/Sahha/Features/HealthKit/Coordinators/DataLogs/HealthKitDataLogCoordinator.swift
@@ -57,6 +57,12 @@ actor HealthKitDataLogCoordinator: HealthKitDataLogCoordinatorProtocol, Disposab
             
             if result.status == .failed, let error = result.errorDescription {
                 print("[HealthKitDataLogCoordinator] Background query error for \(sensor.rawValue): \(error)")
+                // Schedule background refresh to retry failed queries
+                Sahha.scheduleBackgroundRefreshIfNeeded(timeInterval: 300) // 5 minutes
+            } else if result.logsProduced > 0 {
+                // Data was queued for upload - schedule background refresh as safety net
+                // in case uploads don't complete before app is suspended
+                Sahha.scheduleBackgroundRefreshIfNeeded(timeInterval: 900) // 15 minutes
             }
         }
         try await observerService.enableBackgroundDelivery(for: sensors)

--- a/Sources/Sahha/Features/HealthKit/Coordinators/SahhaSamples/HealthKitSahhaSampleCoordinator.swift
+++ b/Sources/Sahha/Features/HealthKit/Coordinators/SahhaSamples/HealthKitSahhaSampleCoordinator.swift
@@ -47,7 +47,6 @@ final class HealthKitSahhaSampleCoordinator: HealthKitSahhaSampleCoordinatorProt
 
             return samples.flatMap(normaliser.normalise)
         } catch {
-            logger.postError(error)
             throw error
         }
 

--- a/Sources/Sahha/Features/HealthKit/Coordinators/SahhaStats/HealthKitSahhaStatCoordinator.swift
+++ b/Sources/Sahha/Features/HealthKit/Coordinators/SahhaStats/HealthKitSahhaStatCoordinator.swift
@@ -67,7 +67,6 @@ final class HealthKitSahhaStatCoordinator: HealthKitSahhaStatCoordinatorProtocol
                 sortDescriptors: nil
             ).compactMap { $0 as? HKCategorySample }
         } catch {
-            logger.postError(error)
             throw error
         }
 
@@ -156,7 +155,6 @@ final class HealthKitSahhaStatCoordinator: HealthKitSahhaStatCoordinatorProtocol
                 sortDescriptors: nil
             ).compactMap { $0 as? HKWorkout }
         } catch {
-            logger.postError(error)
             throw error
         }
 
@@ -251,7 +249,6 @@ final class HealthKitSahhaStatCoordinator: HealthKitSahhaStatCoordinatorProtocol
                 interval: dateComponents
             )
         } catch {
-            logger.postError(error)
             throw error
         }
 

--- a/Sources/Sahha/Features/HealthKit/Managers/HealthKitManager.swift
+++ b/Sources/Sahha/Features/HealthKit/Managers/HealthKitManager.swift
@@ -42,7 +42,7 @@ final class HealthKitManager: HealthKitManagerProtocol {
             // Overwrite store with newly enabled sensors
             try await sensorStore.setSensors(sensors)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     
         // Request permissions and start data collection
@@ -55,7 +55,7 @@ final class HealthKitManager: HealthKitManagerProtocol {
             let sensors = try await sensorStore.getSensors()
             try await dataLogCoordinator.startDataLogCollection(for: sensors)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
         }
     }
     
@@ -65,7 +65,7 @@ final class HealthKitManager: HealthKitManagerProtocol {
             let results = await dataLogCoordinator.querySensors(sensors)
             return PostSensorDataResult(sensorResults: results)
         } catch {
-            logger.postError(error)
+            // Non-critical: silent failure
             return PostSensorDataResult(sensorResults: [], errorDescription: error.localizedDescription)
         }
     }
@@ -97,7 +97,7 @@ final class HealthKitManager: HealthKitManagerProtocol {
                 default: break
                 }
             } catch {
-                logger.postError(error)
+                // Non-critical: silent failure
             }
         }
         if await sensorStore.hasSensor(.date_of_birth) {
@@ -106,7 +106,7 @@ final class HealthKitManager: HealthKitManagerProtocol {
                     demographic.birthDate = dateOfBirth.isoDate
                 }
             } catch {
-                logger.postError(error)
+                // Non-critical: silent failure
             }
         }
         return demographic

--- a/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
+++ b/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
@@ -1,4 +1,5 @@
 import HealthKit
+import UIKit
 
 final class HealthKitObserverService: HealthKitObserverServiceProtocol {
     private let healthStore: HKHealthStore
@@ -38,9 +39,18 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
                     let wrappedCompletion = SendableCompletion(run: completion)
                     
                     Task {
-                        defer { wrappedCompletion.run() }
+                        guard let self else {
+                            wrappedCompletion.run()
+                            return
+                        }
                         
-                        guard let self else { return }
+                        // Request background execution time to ensure query + upload completes
+                        let backgroundTaskId = await self.beginBackgroundTask(for: sensor)
+                        
+                        defer {
+                            wrappedCompletion.run()
+                            self.endBackgroundTask(backgroundTaskId)
+                        }
                         
                         // If circuit breaker exists, check if system is healthy
                         if let circuitBreaker = self.circuitBreaker {
@@ -53,12 +63,31 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
                         }
                         
                         // Circuit is healthy or doesn't exist - proceed with query
+                        print("[HealthKitObserver] Background delivery triggered for \(sensor.rawValue)")
                         await handler(sensor, sampleType)
+                        print("[HealthKitObserver] Background delivery completed for \(sensor.rawValue)")
                     }
                 }
             }
             await observerStore.addObserver(query, for: sensor)
             healthStore.execute(query)
+        }
+    }
+    
+    /// Request additional background execution time from iOS
+    @MainActor
+    private func beginBackgroundTask(for sensor: SahhaSensor) -> UIBackgroundTaskIdentifier {
+        return UIApplication.shared.beginBackgroundTask(withName: "Sahha.HealthKit.\(sensor.rawValue)") {
+            // Expiration handler - called when time is about to run out
+            print("[HealthKitObserver] Background task expiring for \(sensor.rawValue)")
+        }
+    }
+    
+    /// End background task when work is complete
+    private func endBackgroundTask(_ taskId: UIBackgroundTaskIdentifier) {
+        guard taskId != .invalid else { return }
+        Task { @MainActor in
+            UIApplication.shared.endBackgroundTask(taskId)
         }
     }
     

--- a/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
+++ b/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
@@ -31,7 +31,7 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
     private func startObserver(for sensor: SahhaSensor, handler: @escaping HealthKitObserverHandler) async throws {
         if let sampleType = sensor.hkSampleType, try await permissions.hasPermissions(for: sensor) {
             let query = HKObserverQuery(sampleType: sampleType, predicate: nil) { [weak self] _, completion, error in
-                if let error {
+                if error != nil {
                     completion()
                 } else {
                     // Check circuit breaker state before triggering query

--- a/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
+++ b/Sources/Sahha/Features/HealthKit/Observers/HealthKitObserverService.swift
@@ -32,7 +32,6 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
         if let sampleType = sensor.hkSampleType, try await permissions.hasPermissions(for: sensor) {
             let query = HKObserverQuery(sampleType: sampleType, predicate: nil) { [weak self] _, completion, error in
                 if let error {
-                    self?.logger.postError(error)
                     completion()
                 } else {
                     // Check circuit breaker state before triggering query
@@ -57,15 +56,15 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
                             let isHealthy = await circuitBreaker.isHealthy()
                             if !isHealthy {
                                 let (state, _) = await circuitBreaker.getState()
-                                print("[HealthKitObserver] Skipping query for \(sensor.rawValue) - circuit breaker is \(state)")
+                                Sahha.log("[HealthKitObserver] Skipping query for \(sensor.rawValue) - circuit breaker is \(state)")
                                 return
                             }
                         }
                         
                         // Circuit is healthy or doesn't exist - proceed with query
-                        print("[HealthKitObserver] Background delivery triggered for \(sensor.rawValue)")
+                        Sahha.log("[HealthKitObserver] Background delivery triggered for \(sensor.rawValue)")
                         await handler(sensor, sampleType)
-                        print("[HealthKitObserver] Background delivery completed for \(sensor.rawValue)")
+                        Sahha.log("[HealthKitObserver] Background delivery completed for \(sensor.rawValue)")
                     }
                 }
             }
@@ -79,7 +78,7 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
     private func beginBackgroundTask(for sensor: SahhaSensor) -> UIBackgroundTaskIdentifier {
         return UIApplication.shared.beginBackgroundTask(withName: "Sahha.HealthKit.\(sensor.rawValue)") {
             // Expiration handler - called when time is about to run out
-            print("[HealthKitObserver] Background task expiring for \(sensor.rawValue)")
+            Sahha.log("[HealthKitObserver] Background task expiring for \(sensor.rawValue)")
         }
     }
     
@@ -138,7 +137,6 @@ final class HealthKitObserverService: HealthKitObserverServiceProtocol {
         do {
             try await healthStore.disableAllBackgroundDelivery()
         } catch {
-            logger.postError(error)
         }
     }
 }

--- a/Sources/Sahha/Features/HealthKit/Uploaders/HealthKitActivitySummaryUploader.swift
+++ b/Sources/Sahha/Features/HealthKit/Uploaders/HealthKitActivitySummaryUploader.swift
@@ -70,7 +70,6 @@ final class HealthKitActivitySummaryUploader: HealthKitActivitySummaryUploaderPr
                 throw error
             }
         } catch {
-            logger.postError(error)
         }
     }
 

--- a/Sources/Sahha/Sahha.swift
+++ b/Sources/Sahha/Sahha.swift
@@ -16,7 +16,7 @@ public class Sahha {
     static let authSnapshot = AuthSnapshot()
 
     /// Controls whether internal SDK logs are logged. Off by default.
-    public static var debugLogging = false
+    nonisolated(unsafe) public static var debugLogging = false
 
     static func log(_ message: @autoclosure () -> String) {
         guard debugLogging else { return }

--- a/Sources/Sahha/Sahha.swift
+++ b/Sources/Sahha/Sahha.swift
@@ -15,6 +15,14 @@ public class Sahha {
     private static let actor: SahhaActor = .shared
     static let authSnapshot = AuthSnapshot()
 
+    /// Controls whether internal SDK logs are logged. Off by default.
+    public static var debugLogging = false
+
+    static func log(_ message: @autoclosure () -> String) {
+        guard debugLogging else { return }
+        print(message())
+    }
+
     // MARK: - Configuration
     public static func configure(_ settings: SahhaSettings, callback: (() -> Void)? = nil) {
         let box = VoidCallbackBox(callback: callback)
@@ -25,7 +33,7 @@ public class Sahha {
                     box.callback?()
                 }
             } catch {
-                print("[\(SDK.name)] ERROR: Failed to configure Sahha: \(error.localizedDescription)")
+                Sahha.log("[\(SDK.name)] ERROR: Failed to configure Sahha: \(error.localizedDescription)")
             }
         }
     }
@@ -173,7 +181,7 @@ public class Sahha {
                 let delegate = try await actor.backgroundDelegate()
                 delegate.setCompletionHandler(completionHandler, for: identifier)
             } catch {
-                print("[\(SDK.name)] Failed to handle background session events: \(error)")
+                Sahha.log("[\(SDK.name)] Failed to handle background session events: \(error)")
                 completionHandler()
             }
         }
@@ -209,7 +217,7 @@ public class Sahha {
             }
         }
         
-        print("[\(SDK.name)] Background refresh enabled with identifier: \(identifier)")
+        Sahha.log("[\(SDK.name)] Background refresh enabled with identifier: \(identifier)")
     }
     
     /// Legacy method - registers a background app refresh task.
@@ -229,9 +237,9 @@ public class Sahha {
         
         do {
             try BGTaskScheduler.shared.submit(request)
-            print("[\(SDK.name)] Scheduled background refresh for \(Int(timeInterval/60)) minutes from now")
+            Sahha.log("[\(SDK.name)] Scheduled background refresh for \(Int(timeInterval/60)) minutes from now")
         } catch {
-            print("[\(SDK.name)] Failed to schedule background refresh: \(error)")
+            Sahha.log("[\(SDK.name)] Failed to schedule background refresh: \(error)")
         }
     }
     
@@ -244,13 +252,13 @@ public class Sahha {
     }
     
     private static func handleBackgroundRefreshTask(_ task: BGAppRefreshTask) {
-        print("[\(SDK.name)] Background refresh task started")
+        Sahha.log("[\(SDK.name)] Background refresh task started")
         
         // Schedule the next refresh immediately (before doing work)
         scheduleBackgroundRefreshTask(identifier: task.identifier)
         
         task.expirationHandler = {
-            print("[\(SDK.name)] Background refresh task expiring")
+            Sahha.log("[\(SDK.name)] Background refresh task expiring")
             // The system is killing the task.
             // postSensorData doesn't currently support explicit cancellation,
             // but the process termination will stop it.
@@ -262,7 +270,7 @@ public class Sahha {
         postSensorData { result in
             // Mark task as completed with actual success status
             let success = result.failedSensors == 0 && result.errorDescription == nil
-            print("[\(SDK.name)] Background refresh task completed (success: \(success))")
+            Sahha.log("[\(SDK.name)] Background refresh task completed (success: \(success))")
             sendableTask.task.setTaskCompleted(success: success)
         }
     }
@@ -345,7 +353,7 @@ public class Sahha {
             guard let settingsURL = URL(string: UIApplication.openSettingsURLString),
                 UIApplication.shared.canOpenURL(settingsURL)
             else {
-                print("Failed to open app settings: Invalid or unsupported settings URL.")
+                Sahha.log("Failed to open app settings: Invalid or unsupported settings URL.")
                 return
             }
             await UIApplication.shared.open(settingsURL)
@@ -432,13 +440,13 @@ public class Sahha {
     }
 
     private static func logPostSensorData(_ result: PostSensorDataResult) {
-        print("[PostSensorData] Timestamp: \(result.timestamp)")
+        Sahha.log("[PostSensorData] Timestamp: \(result.timestamp)")
         if let error = result.errorDescription {
-            print("  Error: \(error)")
+            Sahha.log("  Error: \(error)")
         }
-        print("  Sensors Queried: \(result.totalSensors)")
-        print("  Samples Fetched: \(result.totalSamples)")
-        print("  Logs Produced: \(result.totalLogs)")
-        print("  Success: \(result.successfulSensors) | Failed: \(result.failedSensors) | Skipped: \(result.skippedSensors)")
+        Sahha.log("  Sensors Queried: \(result.totalSensors)")
+        Sahha.log("  Samples Fetched: \(result.totalSamples)")
+        Sahha.log("  Logs Produced: \(result.totalLogs)")
+        Sahha.log("  Success: \(result.successfulSensors) | Failed: \(result.failedSensors) | Skipped: \(result.skippedSensors)")
     }
 }

--- a/Sources/Sahha/Sahha.swift
+++ b/Sources/Sahha/Sahha.swift
@@ -181,18 +181,45 @@ public class Sahha {
     
     // MARK: - Background App Refresh
     
-    /// Registers a background app refresh task to ensure reliable data collection.
+    /// Stored identifier for auto-scheduling background tasks
+    nonisolated(unsafe) private static var backgroundTaskIdentifier: String?
+    nonisolated(unsafe) private static var backgroundObserver: NSObjectProtocol?
+    
+    /// Enables automatic background refresh for reliable data collection.
+    /// This registers the task and automatically schedules refreshes when the app enters background.
     /// Call this in `application(_:didFinishLaunchingWithOptions:)`.
     /// - Parameter identifier: The identifier for the background task (must match Info.plist)
-    public static func registerBackgroundRefreshTask(identifier: String) {
+    public static func enableBackgroundRefresh(identifier: String) {
+        backgroundTaskIdentifier = identifier
+        
+        // Register the background task
         BGTaskScheduler.shared.register(forTaskWithIdentifier: identifier, using: nil) { task in
             guard let task = task as? BGAppRefreshTask else { return }
             handleBackgroundRefreshTask(task)
         }
+        
+        // Auto-schedule when app enters background
+        if backgroundObserver == nil {
+            backgroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                scheduleBackgroundRefreshIfNeeded()
+            }
+        }
+        
+        print("[\(SDK.name)] Background refresh enabled with identifier: \(identifier)")
+    }
+    
+    /// Legacy method - registers a background app refresh task.
+    /// Prefer `enableBackgroundRefresh(identifier:)` for automatic scheduling.
+    /// - Parameter identifier: The identifier for the background task (must match Info.plist)
+    public static func registerBackgroundRefreshTask(identifier: String) {
+        enableBackgroundRefresh(identifier: identifier)
     }
     
     /// Schedules the next background app refresh.
-    /// Call this when the app enters background or after a successful refresh.
     /// - Parameters:
     ///   - identifier: The identifier for the background task
     ///   - timeInterval: The minimum time interval (in seconds) to wait before the task runs (default: 15 minutes)
@@ -202,16 +229,28 @@ public class Sahha {
         
         do {
             try BGTaskScheduler.shared.submit(request)
+            print("[\(SDK.name)] Scheduled background refresh for \(Int(timeInterval/60)) minutes from now")
         } catch {
             print("[\(SDK.name)] Failed to schedule background refresh: \(error)")
         }
     }
     
+    /// Internal method to schedule refresh using stored identifier
+    internal static func scheduleBackgroundRefreshIfNeeded(timeInterval: TimeInterval = 900) {
+        guard let identifier = backgroundTaskIdentifier else {
+            return // Background refresh not enabled
+        }
+        scheduleBackgroundRefreshTask(identifier: identifier, timeInterval: timeInterval)
+    }
+    
     private static func handleBackgroundRefreshTask(_ task: BGAppRefreshTask) {
-        // Schedule the next refresh immediately
+        print("[\(SDK.name)] Background refresh task started")
+        
+        // Schedule the next refresh immediately (before doing work)
         scheduleBackgroundRefreshTask(identifier: task.identifier)
         
         task.expirationHandler = {
+            print("[\(SDK.name)] Background refresh task expiring")
             // The system is killing the task.
             // postSensorData doesn't currently support explicit cancellation,
             // but the process termination will stop it.
@@ -223,6 +262,7 @@ public class Sahha {
         postSensorData { result in
             // Mark task as completed with actual success status
             let success = result.failedSensors == 0 && result.errorDescription == nil
+            print("[\(SDK.name)] Background refresh task completed (success: \(success))")
             sendableTask.task.setTaskCompleted(success: success)
         }
     }

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -93,10 +93,16 @@ actor SahhaActor {
             let deviceInfoSyncListener = try await container.resolve(DeviceInfoSyncLifecycleListener.self)
             let postInsightsListener = try await container.resolve(PostInsightsLifecycleListener.self)
             let deviceLogListener = try await container.resolve(DeviceLogLifecycleListener.self)
+            let dataLogRetryListener = try await container.resolve(DataLogRetryLifecycleListener.self)
 
             await lifecycleObserver.registerListener(deviceInfoSyncListener, for: [.app_resume])
             await lifecycleObserver.registerListener(postInsightsListener, for: [.app_resume])
             await deviceLogListener.setAuthenticated(true)
+            
+            // Retry pending uploads on resume, foreground, and unlock events.
+            // This ensures data queued during background delivery (but not uploaded
+            // before suspension) gets sent when the app next wakes.
+            await lifecycleObserver.registerListener(dataLogRetryListener, for: [.app_resume, .app_foreground, .app_unlocked])
         } catch {
             await log(error: error, message: "setupLifecycleListeners failed")
         }

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -191,7 +191,7 @@ actor SahhaActor {
         if let logger = (try? await container?.resolve(ErrorLoggerProtocol.self)) {
             logger.postError(error)
         } else {
-            print("\(message): \(error)")
+            Sahha.log("\(message): \(error)")
         }
     }
     
@@ -200,7 +200,7 @@ actor SahhaActor {
         if let logger = (try? await container?.resolve(ErrorLoggerProtocol.self)) {
             logger.postError(error)
         } else {
-            print("[Sahha] Error (logger unavailable): \(error)")
+            Sahha.log("[Sahha] Error (logger unavailable): \(error)")
         }
     }
 
@@ -251,9 +251,9 @@ actor SahhaActor {
         )
         do {
             try await apiClient.send(request)
-            print("[Sahha] Error log sent successfully")
+            Sahha.log("[Sahha] Error log sent successfully")
         } catch {
-            print("[Sahha] Failed to send error log: \(error.localizedDescription)")
+            Sahha.log("[Sahha] Failed to send error log: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Background task protection**: Requests `UIBackgroundTaskIdentifier` in both the HealthKit observer and DataLog uploader so iOS keeps the app alive long enough for uploads to finish after background delivery triggers.
- **Synchronous upload loop**: Runs uploads sequentially within the upload loop instead of spawning detached `Task`s that outlived the background task protection window.
- **Retry on wake**: Adds `DataLogRetryLifecycleListener` that retries any persisted-but-not-uploaded batches when the app resumes, enters foreground, or is unlocked.
- **Auto-scheduled background refresh**: Automatically schedules `BGAppRefreshTask` when the app enters background and after failed uploads/queries as a safety net to retry later.
- **NWPathMonitor fix**: Creates a fresh `NWPathMonitor` instance each time monitoring starts, since `cancel()` is irreversible on a single instance.

## Files Changed

| File | Change |
|------|--------|
| `NetworkMonitor.swift` | Fix single-use NWPathMonitor by recreating on each start |
| `DataLogUploader.swift` | Add background task protection, synchronous upload loop, retry logic |
| `DataLogUploaderProtocol.swift` | Add `retryPendingUploads()` to protocol |
| `DataLogRetryLifecycleListener.swift` | **New** - lifecycle listener that retries pending uploads |
| `DataLogDI.swift` | Register the new retry listener |
| `HealthKitObserverService.swift` | Add background task protection around observer callbacks |
| `HealthKitDataLogCoordinator.swift` | Schedule background refresh after failed/successful queries |
| `Sahha.swift` | Add `enableBackgroundRefresh()`, auto-scheduling, internal `scheduleBackgroundRefreshIfNeeded()` |
| `SahhaActor.swift` | Register retry listener for resume/foreground/unlock events |
