### PR TITLE
Sensor health check: verify and re-register observers on app_foreground

### DIFF
--- a/Sources/Sahha/Features/HealthKit/DI/HealthKitDI.swift
+++ b/Sources/Sahha/Features/HealthKit/DI/HealthKitDI.swift
@@ -169,5 +169,13 @@ enum HealthKitDI {
                 healthKitManager: try await container.resolve(HealthKitManagerProtocol.self)
             )
         }
+        await container.register(SensorHealthCheckLifecycleListener.self) { container in
+            SensorHealthCheckLifecycleListener(
+                sensorStore: try await container.resolve(SensorStoreProtocol.self),
+                observerStore: try await container.resolve(HealthKitObserverStoreProtocol.self),
+                healthKitManager: try await container.resolve(HealthKitManagerProtocol.self),
+                logger: try await container.resolve(ErrorLoggerProtocol.self)
+            )
+        }
     }
 }

--- a/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckLifecycleListener.swift
+++ b/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckLifecycleListener.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+final class SensorHealthCheckLifecycleListener: LifecycleListener, @unchecked Sendable {
+    private let sensorStore: SensorStoreProtocol
+    private let observerStore: HealthKitObserverStoreProtocol
+    private let healthKitManager: HealthKitManagerProtocol
+    private let logger: ErrorLoggerProtocol
+
+    private let _latestResult = LatestResultHolder()
+
+    init(
+        sensorStore: SensorStoreProtocol,
+        observerStore: HealthKitObserverStoreProtocol,
+        healthKitManager: HealthKitManagerProtocol,
+        logger: ErrorLoggerProtocol
+    ) {
+        self.sensorStore = sensorStore
+        self.observerStore = observerStore
+        self.healthKitManager = healthKitManager
+        self.logger = logger
+    }
+
+    func handleLifecycleEvent(_ event: LifecycleEvent) async {
+        let result = await runHealthCheck()
+        await _latestResult.set(result)
+
+        if !result.allHealthy {
+            Sahha.log("[SensorHealthCheck] Re-registered \(result.sensorsReRegistered.count) observer(s), \(result.failures.count) failure(s)")
+        }
+    }
+
+    func getLatestResult() async -> SensorHealthCheckResult? {
+        await _latestResult.get()
+    }
+
+    private func runHealthCheck() async -> SensorHealthCheckResult {
+        let enabledSensors: Set<SahhaSensor>
+        do {
+            enabledSensors = try await sensorStore.getSensors()
+        } catch {
+            return SensorHealthCheckResult(
+                timestamp: Date(),
+                sensorsChecked: [],
+                sensorsReRegistered: [],
+                failures: [:]
+            )
+        }
+
+        guard !enabledSensors.isEmpty else {
+            return SensorHealthCheckResult(
+                timestamp: Date(),
+                sensorsChecked: [],
+                sensorsReRegistered: [],
+                failures: [:]
+            )
+        }
+
+        let registeredKeys = await observerStore.getRegisteredKeys()
+        let missingSensors = enabledSensors.filter { sensor in
+            sensor.hkSampleType != nil && !registeredKeys.contains(sensor.rawValue)
+        }
+
+        var reRegistered = Set<SahhaSensor>()
+        var failures: [SahhaSensor: String] = [:]
+
+        if !missingSensors.isEmpty {
+            Sahha.log("[SensorHealthCheck] Missing observers for: \(missingSensors.map(\.rawValue).sorted().joined(separator: ", "))")
+
+            // Re-register all sensors through the standard flow.
+            // resumeSensors() handles the dataLog/tag split and is idempotent
+            // for already-registered sensors.
+            await healthKitManager.resumeSensors()
+
+            // Verify which sensors were successfully re-registered
+            let updatedKeys = await observerStore.getRegisteredKeys()
+            for sensor in missingSensors {
+                if updatedKeys.contains(sensor.rawValue) {
+                    reRegistered.insert(sensor)
+                } else {
+                    let message = "Observer re-registration failed for \(sensor.rawValue)"
+                    failures[sensor] = message
+                    logger.postError(SahhaError(message: message))
+                }
+            }
+        }
+
+        return SensorHealthCheckResult(
+            timestamp: Date(),
+            sensorsChecked: enabledSensors,
+            sensorsReRegistered: reRegistered,
+            failures: failures
+        )
+    }
+}
+
+private actor LatestResultHolder {
+    private var result: SensorHealthCheckResult?
+
+    func set(_ value: SensorHealthCheckResult) {
+        result = value
+    }
+
+    func get() -> SensorHealthCheckResult? {
+        result
+    }
+}

--- a/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckResult.swift
+++ b/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckResult.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct SensorHealthCheckResult: Sendable {
+    let timestamp: Date
+    let sensorsChecked: Set<SahhaSensor>
+    let sensorsReRegistered: Set<SahhaSensor>
+    let failures: [SahhaSensor: String]
+
+    var allHealthy: Bool {
+        sensorsReRegistered.isEmpty && failures.isEmpty
+    }
+}

--- a/Sources/Sahha/Features/HealthKit/Stores/HealthKitObserverStore.swift
+++ b/Sources/Sahha/Features/HealthKit/Stores/HealthKitObserverStore.swift
@@ -15,4 +15,8 @@ actor HealthKitObserverStore: HealthKitObserverStoreProtocol {
         defer { observers.removeAll() }
         return Array(observers.values)
     }
+
+    func getRegisteredKeys() -> Set<String> {
+        Set(observers.keys)
+    }
 }

--- a/Sources/Sahha/Features/HealthKit/Stores/HealthKitObserverStoreProtocol.swift
+++ b/Sources/Sahha/Features/HealthKit/Stores/HealthKitObserverStoreProtocol.swift
@@ -4,6 +4,7 @@ protocol HealthKitObserverStoreProtocol: Actor {
     func addObserver(_ observer: HKObserverQuery, forKey key: String)
     func removeObserver(forKey key: String) -> HKObserverQuery?
     func removeAllObservers() -> [HKObserverQuery]
+    func getRegisteredKeys() -> Set<String>
 }
 
 extension HealthKitObserverStoreProtocol {

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -100,6 +100,7 @@ actor SahhaActor {
             let deviceLogListener = try await container.resolve(DeviceLogLifecycleListener.self)
             let dataLogRetryListener = try await container.resolve(DataLogRetryLifecycleListener.self)
             let tagRetryListener = try await container.resolve(TagRetryLifecycleListener.self)
+            let sensorHealthCheckListener = try await container.resolve(SensorHealthCheckLifecycleListener.self)
 
             await lifecycleObserver.registerListener(deviceInfoSyncListener, for: [.app_resume])
             await lifecycleObserver.registerListener(postInsightsListener, for: [.app_resume])
@@ -110,6 +111,10 @@ actor SahhaActor {
             // before suspension) gets sent when the app next wakes.
             await lifecycleObserver.registerListener(dataLogRetryListener, for: [.app_resume, .app_foreground, .app_unlocked])
             await lifecycleObserver.registerListener(tagRetryListener, for: [.app_resume, .app_foreground, .app_unlocked])
+
+            // Verify observer health on every foreground event — re-registers any
+            // observers silently dropped by iOS (memory pressure, OS updates, etc.)
+            await lifecycleObserver.registerListener(sensorHealthCheckListener, for: [.app_foreground])
         } catch {
             await log(error: error, message: "setupLifecycleListeners failed")
         }


### PR DESCRIPTION
## Summary
- New `SensorHealthCheckLifecycleListener` triggers on every `app_foreground` lifecycle event
- Compares enabled sensors (from `SensorStore`) against registered observers (from `HealthKitObserverStore`) to detect silently dropped observers
- Missing observers are re-registered via `resumeSensors()` which handles the dataLog/tag coordinator split
- Re-registration failures are logged through `ErrorLogger`
- `SensorHealthCheckResult` struct stores check results (sensors checked, re-registered, failures) for consumption by diagnostic report system
- Added `getRegisteredKeys()` to `HealthKitObserverStoreProtocol` for non-destructive observer existence checks
- Registered in DI container and wired into `SahhaActor.setupLifecycleListeners()`

Closes #27