### PR TITLE
Probe query + .indeterminate status + internal per-sensor tracking

### DIFF
--- a/Sources/Sahha/Features/HealthKit/Managers/HealthKitManager.swift
+++ b/Sources/Sahha/Features/HealthKit/Managers/HealthKitManager.swift
@@ -113,6 +113,17 @@ final class HealthKitManager: HealthKitManagerProtocol {
             return .pending
         }
         guard expanded.isSubset(of: enabledSensors) else { return .pending }
+
+        // Check per-sensor probe results — map .indeterminate to .enabled
+        // for backward compatibility. Per-sensor breakdown will be exposed
+        // in a future release.
+        let statuses = await sensorStore.getSensorStatuses()
+        for sensor in expanded {
+            if let sensorStatus = statuses[sensor], sensorStatus == .indeterminate {
+                // Internally tracked but externally reported as .enabled
+                continue
+            }
+        }
         return .enabled
     }
 

--- a/Sources/Sahha/Features/Sensors/DI/SensorDI.swift
+++ b/Sources/Sahha/Features/Sensors/DI/SensorDI.swift
@@ -5,5 +5,12 @@ enum SensorDI {
                 storage: try await container.resolve(UserDefaultsStorageProtocol.self)
             )
         }
+        await container.register(SensorProbeLifecycleListener.self) { container in
+            SensorProbeLifecycleListener(
+                sensorStore: try await container.resolve(SensorStoreProtocol.self),
+                sampleQueryService: try await container.resolve(HealthKitSampleQueryServiceProtocol.self),
+                logger: try await container.resolve(ErrorLoggerProtocol.self)
+            )
+        }
     }
 }

--- a/Sources/Sahha/Features/Sensors/Enums/SahhaSensorStatus.swift
+++ b/Sources/Sahha/Features/Sensors/Enums/SahhaSensorStatus.swift
@@ -3,6 +3,7 @@ public enum SahhaSensorStatus: String, Sendable {
     case unavailable /// Sensor data is not supported by the User's device
     case disabled /// Sensor data has been disabled by the User
     case enabled /// Sensor data has been enabled by the User
+    case indeterminate /// Sensor may be denied or simply has no data yet
     public var description: String {
         String(describing: self)
     }

--- a/Sources/Sahha/Features/Sensors/Listeners/SensorProbeLifecycleListener.swift
+++ b/Sources/Sahha/Features/Sensors/Listeners/SensorProbeLifecycleListener.swift
@@ -1,0 +1,57 @@
+import HealthKit
+
+final class SensorProbeLifecycleListener: LifecycleListener, @unchecked Sendable {
+    private let sensorStore: SensorStoreProtocol
+    private let sampleQueryService: HealthKitSampleQueryServiceProtocol
+    private let logger: ErrorLoggerProtocol
+
+    init(
+        sensorStore: SensorStoreProtocol,
+        sampleQueryService: HealthKitSampleQueryServiceProtocol,
+        logger: ErrorLoggerProtocol
+    ) {
+        self.sensorStore = sensorStore
+        self.sampleQueryService = sampleQueryService
+        self.logger = logger
+    }
+
+    func handleLifecycleEvent(_ event: LifecycleEvent) async {
+        await runProbe()
+    }
+
+    private func runProbe() async {
+        let enabledSensors: Set<SahhaSensor>
+        do {
+            enabledSensors = try await sensorStore.getSensors()
+        } catch {
+            return
+        }
+
+        guard !enabledSensors.isEmpty else { return }
+
+        var statuses: [SahhaSensor: SahhaSensorStatus] = [:]
+
+        for sensor in enabledSensors {
+            guard let sampleType = sensor.hkSampleType else { continue }
+
+            do {
+                let predicate = HKQuery.predicateForSamples(
+                    withStart: Calendar.current.date(byAdding: .hour, value: -24, to: Date()),
+                    end: Date(),
+                    options: .strictStartDate
+                )
+                let samples = try await sampleQueryService.runSampleQuery(
+                    for: sampleType,
+                    predicate: predicate,
+                    limit: 1,
+                    sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)]
+                )
+                statuses[sensor] = samples.isEmpty ? .indeterminate : .enabled
+            } catch {
+                statuses[sensor] = .indeterminate
+            }
+        }
+
+        await sensorStore.setSensorStatuses(statuses)
+    }
+}

--- a/Sources/Sahha/Features/Sensors/Stores/SensorStore.swift
+++ b/Sources/Sahha/Features/Sensors/Stores/SensorStore.swift
@@ -1,31 +1,40 @@
 actor SensorStore: SensorStoreProtocol {
     private let storage: UserDefaultsStorageProtocol
     private let key: String
-    
+
     private var sensors: Set<SahhaSensor>?
-    
+    private var sensorStatuses: [SahhaSensor: SahhaSensorStatus] = [:]
+
     init(
         storage: UserDefaultsStorageProtocol = UserDefaultsStorage(),
         key: String = StorageKeys.UserDefaults.sensors
     ) {
         self.storage = storage
         self.key = key
-        
+
         self.sensors = try? storage.object(forKey: key)
     }
-    
+
     func setSensors(_ sensors: Set<SahhaSensor>) throws {
         try storage.setObject(sensors, forKey: key)
         self.sensors = sensors
     }
-    
+
     func getSensors() throws -> Set<SahhaSensor> {
         if let sensors { return sensors }
         self.sensors = try storage.object(forKey: key)
         return self.sensors ?? []
     }
-    
+
     func hasSensor(_ sensor: SahhaSensor) -> Bool {
         sensors?.contains(sensor) ?? false
+    }
+
+    func setSensorStatuses(_ statuses: [SahhaSensor: SahhaSensorStatus]) {
+        sensorStatuses = statuses
+    }
+
+    func getSensorStatuses() -> [SahhaSensor: SahhaSensorStatus] {
+        sensorStatuses
     }
 }

--- a/Sources/Sahha/Features/Sensors/Stores/SensorStoreProtocol.swift
+++ b/Sources/Sahha/Features/Sensors/Stores/SensorStoreProtocol.swift
@@ -2,4 +2,6 @@ protocol SensorStoreProtocol: Actor {
     func setSensors(_ sensors: Set<SahhaSensor>) throws
     func getSensors() throws -> Set<SahhaSensor>
     func hasSensor(_ sensor: SahhaSensor) -> Bool
+    func setSensorStatuses(_ statuses: [SahhaSensor: SahhaSensorStatus])
+    func getSensorStatuses() -> [SahhaSensor: SahhaSensorStatus]
 }

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -101,6 +101,7 @@ actor SahhaActor {
             let dataLogRetryListener = try await container.resolve(DataLogRetryLifecycleListener.self)
             let tagRetryListener = try await container.resolve(TagRetryLifecycleListener.self)
             let sensorHealthCheckListener = try await container.resolve(SensorHealthCheckLifecycleListener.self)
+            let sensorProbeListener = try await container.resolve(SensorProbeLifecycleListener.self)
 
             await lifecycleObserver.registerListener(deviceInfoSyncListener, for: [.app_resume])
             await lifecycleObserver.registerListener(postInsightsListener, for: [.app_resume])
@@ -115,6 +116,9 @@ actor SahhaActor {
             // Verify observer health on every foreground event — re-registers any
             // observers silently dropped by iOS (memory pressure, OS updates, etc.)
             await lifecycleObserver.registerListener(sensorHealthCheckListener, for: [.app_foreground])
+
+            // Probe each sensor for data to detect potentially denied permissions
+            await lifecycleObserver.registerListener(sensorProbeListener, for: [.app_foreground])
         } catch {
             await log(error: error, message: "setupLifecycleListeners failed")
         }


### PR DESCRIPTION
## Summary
- Added `.indeterminate` case to `SahhaSensorStatus` enum — represents "possibly denied OR no data recorded yet"
- New `SensorProbeLifecycleListener` runs on every `app_foreground` event, executing a lightweight HKSampleQuery (last 24h, limit 1) per enabled sensor to detect data availability
- Sensors returning data → `.enabled`; sensors returning no data → `.indeterminate`
- Per-sensor status map (`[SahhaSensor: SahhaSensorStatus]`) maintained in `SensorStore` via new `setSensorStatuses`/`getSensorStatuses` methods
- Public `getSensorStatus` API signature unchanged — `.indeterminate` is mapped to `.enabled` externally for backward compatibility
- Registered in DI container (`SensorDI`) and wired into lifecycle observer (`SahhaActor`)

Closes #28