### PR TITLE
Diagnostic report: local snapshot + public SDK method

### DIFF
--- a/Sources/Sahha/Core/Upload/UnifiedUploader.swift
+++ b/Sources/Sahha/Core/Upload/UnifiedUploader.swift
@@ -81,6 +81,10 @@ actor UnifiedUploader<Item: Sendable, Request: UploadableRequest>: Disposable {
         await startUploadLoopIfNeeded()
     }
 
+    func getDLQStatistics() async -> PersistenceStatistics {
+        await persistentQueue.getStatistics()
+    }
+
     func dispose() async {
         uploadTask?.cancel()
         uploadTask = nil

--- a/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploaderProtocol.swift
+++ b/Sources/Sahha/Features/DataLogs/Uploaders/DataLogUploaderProtocol.swift
@@ -1,6 +1,7 @@
 protocol DataLogUploaderProtocol: Actor {
     func enqueueLogs(_ logs: [DataLog]) async
     func retryPendingUploads() async
+    func getDLQStatistics() async -> PersistenceStatistics
     func dispose() async
 }
 

--- a/Sources/Sahha/Features/Diagnostics/Builders/DiagnosticReportBuilder.swift
+++ b/Sources/Sahha/Features/Diagnostics/Builders/DiagnosticReportBuilder.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+protocol DiagnosticReportBuilderProtocol: Sendable {
+    func buildReport() async -> DiagnosticReport
+    func getLatestReport() async -> DiagnosticReport?
+}
+
+actor DiagnosticReportBuilder: DiagnosticReportBuilderProtocol {
+    private let sensorStore: SensorStoreProtocol
+    private let healthCheckListener: SensorHealthCheckLifecycleListener
+    private let dataLogUploader: DataLogUploaderProtocol
+    private let tagUploader: TagUploaderProtocol
+    private let circuitBreaker: CircuitBreaker?
+    private let networkMonitor: NetworkMonitor
+    private let deviceInfoBuilder: DeviceInfoBuilderProtocol
+    private let storage: UserDefaultsStorageProtocol
+
+    private let storageKey = "com.sahha.diagnostic_report"
+
+    init(
+        sensorStore: SensorStoreProtocol,
+        healthCheckListener: SensorHealthCheckLifecycleListener,
+        dataLogUploader: DataLogUploaderProtocol,
+        tagUploader: TagUploaderProtocol,
+        circuitBreaker: CircuitBreaker?,
+        networkMonitor: NetworkMonitor,
+        deviceInfoBuilder: DeviceInfoBuilderProtocol,
+        storage: UserDefaultsStorageProtocol
+    ) {
+        self.sensorStore = sensorStore
+        self.healthCheckListener = healthCheckListener
+        self.dataLogUploader = dataLogUploader
+        self.tagUploader = tagUploader
+        self.circuitBreaker = circuitBreaker
+        self.networkMonitor = networkMonitor
+        self.deviceInfoBuilder = deviceInfoBuilder
+        self.storage = storage
+    }
+
+    func buildReport() async -> DiagnosticReport {
+        let deviceInfo = await deviceInfoBuilder.build()
+
+        let enabledSensors: Set<SahhaSensor> = (try? await sensorStore.getSensors()) ?? []
+        let sensorStatuses = await sensorStore.getSensorStatuses()
+
+        let healthCheck = await healthCheckListener.getLatestResult()
+
+        let dataLogDLQStats = await dataLogUploader.getDLQStatistics()
+        let tagDLQStats = await tagUploader.getDLQStatistics()
+
+        let cbState: (CircuitState, Int)
+        if let circuitBreaker {
+            cbState = await circuitBreaker.getState()
+        } else {
+            cbState = (.closed, 0)
+        }
+
+        let networkConnected = await networkMonitor.isConnected
+
+        let report = DiagnosticReport(
+            timestamp: Date(),
+            sdkVersion: SDK.version,
+            deviceModel: deviceInfo.deviceModel,
+            system: deviceInfo.system,
+            systemVersion: deviceInfo.systemVersion,
+            appId: deviceInfo.appId,
+            enabledSensors: enabledSensors.map(\.rawValue).sorted(),
+            sensorStatuses: Dictionary(
+                uniqueKeysWithValues: sensorStatuses.map { ($0.key.rawValue, $0.value.rawValue) }
+            ),
+            observerStatuses: DiagnosticReport.ObserverSnapshot(
+                sensorsChecked: healthCheck?.sensorsChecked.map(\.rawValue).sorted() ?? [],
+                sensorsReRegistered: healthCheck?.sensorsReRegistered.map(\.rawValue).sorted() ?? [],
+                failures: healthCheck?.failures.reduce(into: [String: String]()) {
+                    $0[$1.key.rawValue] = $1.value
+                } ?? [:],
+                lastCheckTimestamp: healthCheck?.timestamp
+            ),
+            dataLogDLQ: dlqSnapshot(from: dataLogDLQStats),
+            tagDLQ: dlqSnapshot(from: tagDLQStats),
+            circuitBreakerState: String(describing: cbState.0),
+            circuitBreakerFailures: cbState.1,
+            isNetworkConnected: networkConnected
+        )
+
+        try? storage.setObject(report, forKey: storageKey)
+        return report
+    }
+
+    func getLatestReport() async -> DiagnosticReport? {
+        try? storage.object(forKey: storageKey)
+    }
+
+    private func dlqSnapshot(from stats: PersistenceStatistics) -> DiagnosticReport.DLQSnapshot {
+        let oldestAge: TimeInterval?
+        if let oldest = stats.oldestTimestamp {
+            oldestAge = Date().timeIntervalSince1970 - oldest
+        } else {
+            oldestAge = nil
+        }
+        return DiagnosticReport.DLQSnapshot(
+            totalBatches: stats.totalBatches,
+            totalItems: stats.totalItems,
+            failedBatches: stats.failedBatches,
+            oldestBatchAge: oldestAge
+        )
+    }
+}

--- a/Sources/Sahha/Features/Diagnostics/DI/DiagnosticsDI.swift
+++ b/Sources/Sahha/Features/Diagnostics/DI/DiagnosticsDI.swift
@@ -1,0 +1,16 @@
+enum DiagnosticsDI {
+    static func registerDependencies(container: DIContainer) async {
+        await container.register(DiagnosticReportBuilderProtocol.self) { container in
+            DiagnosticReportBuilder(
+                sensorStore: try await container.resolve(SensorStoreProtocol.self),
+                healthCheckListener: try await container.resolve(SensorHealthCheckLifecycleListener.self),
+                dataLogUploader: try await container.resolve(DataLogUploaderProtocol.self),
+                tagUploader: try await container.resolve(TagUploaderProtocol.self),
+                circuitBreaker: try? await container.resolve(CircuitBreaker.self),
+                networkMonitor: try await container.resolve(NetworkMonitor.self),
+                deviceInfoBuilder: try await container.resolve(DeviceInfoBuilderProtocol.self),
+                storage: try await container.resolve(UserDefaultsStorageProtocol.self)
+            )
+        }
+    }
+}

--- a/Sources/Sahha/Features/Diagnostics/Models/DiagnosticReport.swift
+++ b/Sources/Sahha/Features/Diagnostics/Models/DiagnosticReport.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Pipeline health metadata snapshot — contains NO health data values by design (HIPAA/GDPR).
+public struct DiagnosticReport: Codable, Sendable {
+    public let timestamp: Date
+    public let sdkVersion: String
+    public let deviceModel: String
+    public let system: String
+    public let systemVersion: String
+    public let appId: String
+
+    public let enabledSensors: [String]
+    public let sensorStatuses: [String: String]
+    public let observerStatuses: ObserverSnapshot
+    public let dataLogDLQ: DLQSnapshot
+    public let tagDLQ: DLQSnapshot
+    public let circuitBreakerState: String
+    public let circuitBreakerFailures: Int
+    public let isNetworkConnected: Bool
+
+    public struct ObserverSnapshot: Codable, Sendable {
+        public let sensorsChecked: [String]
+        public let sensorsReRegistered: [String]
+        public let failures: [String: String]
+        public let lastCheckTimestamp: Date?
+    }
+
+    public struct DLQSnapshot: Codable, Sendable {
+        public let totalBatches: Int
+        public let totalItems: Int
+        public let failedBatches: Int
+        public let oldestBatchAge: TimeInterval?
+    }
+}

--- a/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckLifecycleListener.swift
+++ b/Sources/Sahha/Features/HealthKit/Listeners/SensorHealthCheckLifecycleListener.swift
@@ -5,6 +5,7 @@ final class SensorHealthCheckLifecycleListener: LifecycleListener, @unchecked Se
     private let observerStore: HealthKitObserverStoreProtocol
     private let healthKitManager: HealthKitManagerProtocol
     private let logger: ErrorLoggerProtocol
+    private var diagnosticReportBuilder: DiagnosticReportBuilderProtocol?
 
     private let _latestResult = LatestResultHolder()
 
@@ -20,6 +21,10 @@ final class SensorHealthCheckLifecycleListener: LifecycleListener, @unchecked Se
         self.logger = logger
     }
 
+    func setDiagnosticReportBuilder(_ builder: DiagnosticReportBuilderProtocol) {
+        self.diagnosticReportBuilder = builder
+    }
+
     func handleLifecycleEvent(_ event: LifecycleEvent) async {
         let result = await runHealthCheck()
         await _latestResult.set(result)
@@ -27,6 +32,9 @@ final class SensorHealthCheckLifecycleListener: LifecycleListener, @unchecked Se
         if !result.allHealthy {
             Sahha.log("[SensorHealthCheck] Re-registered \(result.sensorsReRegistered.count) observer(s), \(result.failures.count) failure(s)")
         }
+
+        // Upsert diagnostic snapshot after each health check
+        _ = await diagnosticReportBuilder?.buildReport()
     }
 
     func getLatestResult() async -> SensorHealthCheckResult? {

--- a/Sources/Sahha/Features/Tags/Uploaders/TagUploaderProtocol.swift
+++ b/Sources/Sahha/Features/Tags/Uploaders/TagUploaderProtocol.swift
@@ -1,6 +1,7 @@
 protocol TagUploaderProtocol: Actor {
     func enqueueTags(_ tags: [Tag]) async
     func retryPendingUploads() async
+    func getDLQStatistics() async -> PersistenceStatistics
     func dispose() async
 }
 

--- a/Sources/Sahha/Sahha.swift
+++ b/Sources/Sahha/Sahha.swift
@@ -361,6 +361,18 @@ public class Sahha {
         }
     }
 
+    // MARK: - Diagnostics
+    public static func getDiagnosticReport(callback: @escaping (String?, DiagnosticReport?) -> Void) {
+        runAsyncWithCallback(
+            callback: callback,
+            requiresAuth: true,
+            task: {
+                let builder = try await actor.diagnosticReportBuilder()
+                return await builder.buildReport()
+            }
+        )
+    }
+
     // MARK: - Errors
     public static func postError(framework: SahhaFramework = .ios_swift, message: String, path: String, method: String, body: String) {
         Task {

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -40,6 +40,7 @@ actor SahhaActor {
             await DemographicDI.registerDependencies(container: container)
             await DeviceInfoSyncDI.registerDependencies(container: container)
             await DeviceLogDI.registerDependencies(container: container)
+            await DiagnosticsDI.registerDependencies(container: container)
 
             // Validate and clean up legacy DLQ files from before the unified pipeline
             let userDefaultsStorage = try await container.resolve(UserDefaultsStorageProtocol.self)
@@ -102,6 +103,10 @@ actor SahhaActor {
             let tagRetryListener = try await container.resolve(TagRetryLifecycleListener.self)
             let sensorHealthCheckListener = try await container.resolve(SensorHealthCheckLifecycleListener.self)
             let sensorProbeListener = try await container.resolve(SensorProbeLifecycleListener.self)
+            let diagnosticReportBuilder = try await container.resolve(DiagnosticReportBuilderProtocol.self)
+
+            // Connect diagnostic report builder to health check listener
+            sensorHealthCheckListener.setDiagnosticReportBuilder(diagnosticReportBuilder)
 
             await lifecycleObserver.registerListener(deviceInfoSyncListener, for: [.app_resume])
             await lifecycleObserver.registerListener(postInsightsListener, for: [.app_resume])
@@ -195,6 +200,10 @@ actor SahhaActor {
 
     func demographicManager() async throws -> DemographicManagerProtocol {
         try await resolve(DemographicManagerProtocol.self)
+    }
+
+    func diagnosticReportBuilder() async throws -> DiagnosticReportBuilderProtocol {
+        try await resolve(DiagnosticReportBuilderProtocol.self)
     }
 
     func tagPipeline() async throws -> TagPipelineProtocol {


### PR DESCRIPTION
## Summary
- New `DiagnosticReport` struct (Codable, Sendable) — contains only pipeline health metadata, NO health data values (HIPAA/GDPR by design)
- Report includes: enabled sensors, per-sensor probe statuses, observer health check results, DLQ statistics (dataLog + tag), circuit breaker state, network connectivity, SDK version, device info
- `DiagnosticReportBuilder` actor collects data from sensor store, health check listener, uploaders, circuit breaker, network monitor, and device info builder
- Snapshot upserted (not appended) to UserDefaults after each health check on `app_foreground` — single snapshot, ~5-10KB
- Public `Sahha.getDiagnosticReport(callback:)` method exposed following existing SDK callback pattern
- Added `getDLQStatistics()` to uploader protocols (`DataLogUploaderProtocol`, `TagUploaderProtocol`) and `UnifiedUploader`
- Registered in DI via `DiagnosticsDI`, wired into `SahhaActor`

Closes #29