### PR TITLE
Diagnostic report: server trigger + remote upload

### DIFF
--- a/Sources/Sahha/Core/Constants/APIEndpoints.swift
+++ b/Sources/Sahha/Core/Constants/APIEndpoints.swift
@@ -8,4 +8,6 @@ enum APIEndpoints {
     static let dataLog = "v2/profile/data/log"
     static let tag = "v1/profile/tag"
     static let error = "v1/error"
+    static let config = "v1/profile/config"
+    static let diagnostic = "v1/profile/diagnostic"
 }

--- a/Sources/Sahha/Features/Diagnostics/DI/DiagnosticsDI.swift
+++ b/Sources/Sahha/Features/Diagnostics/DI/DiagnosticsDI.swift
@@ -12,5 +12,17 @@ enum DiagnosticsDI {
                 storage: try await container.resolve(UserDefaultsStorageProtocol.self)
             )
         }
+        await container.register(DiagnosticUploadServiceProtocol.self) { container in
+            DiagnosticUploadService(
+                apiClient: try await container.resolve(APIClientProtocol.self),
+                reportBuilder: try await container.resolve(DiagnosticReportBuilderProtocol.self),
+                logger: try await container.resolve(ErrorLoggerProtocol.self)
+            )
+        }
+        await container.register(DiagnosticConfigLifecycleListener.self) { container in
+            DiagnosticConfigLifecycleListener(
+                uploadService: try await container.resolve(DiagnosticUploadServiceProtocol.self)
+            )
+        }
     }
 }

--- a/Sources/Sahha/Features/Diagnostics/Listeners/DiagnosticConfigLifecycleListener.swift
+++ b/Sources/Sahha/Features/Diagnostics/Listeners/DiagnosticConfigLifecycleListener.swift
@@ -1,0 +1,11 @@
+final class DiagnosticConfigLifecycleListener: LifecycleListener, @unchecked Sendable {
+    private let uploadService: DiagnosticUploadServiceProtocol
+
+    init(uploadService: DiagnosticUploadServiceProtocol) {
+        self.uploadService = uploadService
+    }
+
+    func handleLifecycleEvent(_ event: LifecycleEvent) async {
+        await uploadService.checkConfigAndUploadIfRequested()
+    }
+}

--- a/Sources/Sahha/Features/Diagnostics/Models/ProfileConfig.swift
+++ b/Sources/Sahha/Features/Diagnostics/Models/ProfileConfig.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct ProfileConfig: Decodable, Sendable {
+    let diagnosticRequested: Bool?
+}

--- a/Sources/Sahha/Features/Diagnostics/Services/DiagnosticUploadService.swift
+++ b/Sources/Sahha/Features/Diagnostics/Services/DiagnosticUploadService.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+protocol DiagnosticUploadServiceProtocol: Sendable {
+    func checkConfigAndUploadIfRequested() async
+    func uploadDiagnosticReport() async throws
+}
+
+final class DiagnosticUploadService: DiagnosticUploadServiceProtocol, @unchecked Sendable {
+    private let apiClient: APIClientProtocol
+    private let reportBuilder: DiagnosticReportBuilderProtocol
+    private let logger: ErrorLoggerProtocol
+
+    init(
+        apiClient: APIClientProtocol,
+        reportBuilder: DiagnosticReportBuilderProtocol,
+        logger: ErrorLoggerProtocol
+    ) {
+        self.apiClient = apiClient
+        self.reportBuilder = reportBuilder
+        self.logger = logger
+    }
+
+    func checkConfigAndUploadIfRequested() async {
+        do {
+            let request = APIRequest(
+                endpoint: APIEndpoints.config,
+                method: .GET,
+                requiresAuth: true
+            )
+            let config: ProfileConfig = try await apiClient.send(request)
+            guard config.diagnosticRequested == true else { return }
+
+            Sahha.log("[Diagnostics] Server requested diagnostic report — collecting and uploading")
+            try await uploadDiagnosticReport()
+        } catch {
+            // Silently ignore config check failures — best effort only
+            Sahha.log("[Diagnostics] Config check failed: \(error.localizedDescription)")
+        }
+    }
+
+    func uploadDiagnosticReport() async throws {
+        let report = await reportBuilder.buildReport()
+        let request = APIRequest(
+            endpoint: APIEndpoints.diagnostic,
+            method: .POST,
+            body: report,
+            requiresAuth: true
+        )
+        try await apiClient.send(request)
+        Sahha.log("[Diagnostics] Diagnostic report uploaded successfully")
+    }
+}

--- a/Sources/Sahha/Sahha.swift
+++ b/Sources/Sahha/Sahha.swift
@@ -373,6 +373,19 @@ public class Sahha {
         )
     }
 
+    public static func uploadDiagnosticReport(callback: @escaping (String?, Bool) -> Void) {
+        runAsyncWithCallback(
+            callback: callback,
+            requiresAuth: true,
+            task: {
+                let service = try await actor.diagnosticUploadService()
+                try await service.uploadDiagnosticReport()
+                return true
+            },
+            defaultErrorValue: false
+        )
+    }
+
     // MARK: - Errors
     public static func postError(framework: SahhaFramework = .ios_swift, message: String, path: String, method: String, body: String) {
         Task {

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -104,6 +104,7 @@ actor SahhaActor {
             let sensorHealthCheckListener = try await container.resolve(SensorHealthCheckLifecycleListener.self)
             let sensorProbeListener = try await container.resolve(SensorProbeLifecycleListener.self)
             let diagnosticReportBuilder = try await container.resolve(DiagnosticReportBuilderProtocol.self)
+            let diagnosticConfigListener = try await container.resolve(DiagnosticConfigLifecycleListener.self)
 
             // Connect diagnostic report builder to health check listener
             sensorHealthCheckListener.setDiagnosticReportBuilder(diagnosticReportBuilder)
@@ -124,6 +125,9 @@ actor SahhaActor {
 
             // Probe each sensor for data to detect potentially denied permissions
             await lifecycleObserver.registerListener(sensorProbeListener, for: [.app_foreground])
+
+            // Check server config for diagnostic report requests
+            await lifecycleObserver.registerListener(diagnosticConfigListener, for: [.app_foreground])
         } catch {
             await log(error: error, message: "setupLifecycleListeners failed")
         }
@@ -204,6 +208,10 @@ actor SahhaActor {
 
     func diagnosticReportBuilder() async throws -> DiagnosticReportBuilderProtocol {
         try await resolve(DiagnosticReportBuilderProtocol.self)
+    }
+
+    func diagnosticUploadService() async throws -> DiagnosticUploadServiceProtocol {
+        try await resolve(DiagnosticUploadServiceProtocol.self)
     }
 
     func tagPipeline() async throws -> TagPipelineProtocol {


### PR DESCRIPTION
## Summary
- New `DiagnosticConfigLifecycleListener` checks `GET /v1/profile/config` on every `app_foreground` — authenticated, lightweight, failure silently ignored
- When `diagnosticRequested: true` in config response, collects a fresh diagnostic snapshot and uploads via `POST /v1/profile/diagnostic`
- Upload is fire-and-forget — not routed through the main upload pipeline, no DLQ, no retry
- Public `Sahha.uploadDiagnosticReport(callback:)` method for host apps to trigger manual diagnostic uploads (e.g., "Send Debug Report" button)
- `DiagnosticUploadService` handles both server-triggered and manual uploads
- `ProfileConfig` response model for the config endpoint
- Added `config` and `diagnostic` API endpoints
- All registered in `DiagnosticsDI` and wired into `SahhaActor.setupLifecycleListeners()`

Closes #30