### PR TITLE
UnifiedUploader.dispose() clears persistent upload queues from disk

### DIFF
--- a/Sources/Sahha/Core/Upload/UnifiedUploader.swift
+++ b/Sources/Sahha/Core/Upload/UnifiedUploader.swift
@@ -89,6 +89,7 @@ actor UnifiedUploader<Item: Sendable, Request: UploadableRequest>: Disposable {
         uploadTask?.cancel()
         uploadTask = nil
         await chunkQueue.clear()
+        await persistentQueue.clearAll()
         await networkMonitor.stopMonitoring()
     }
 


### PR DESCRIPTION
## Summary

- Adds `await persistentQueue.clearAll()` to `UnifiedUploader.dispose()` so that on-disk persistent upload queues (JSON batch files under `data-logs/PersistentQueue/` and `tags/PersistentQueue/`) are deleted during deauthentication
- Prevents sensitive user health data from surviving a deauth/reauth cycle

Closes #41