### PR TITLE
SensorStore adopts Disposable — clear sensors on deauth

### DIFF
--- a/Sources/Sahha/Features/Sensors/Stores/SensorStore.swift
+++ b/Sources/Sahha/Features/Sensors/Stores/SensorStore.swift
@@ -1,4 +1,4 @@
-actor SensorStore: SensorStoreProtocol {
+actor SensorStore: SensorStoreProtocol, Disposable {
     private let storage: UserDefaultsStorageProtocol
     private let key: String
 
@@ -36,5 +36,11 @@ actor SensorStore: SensorStoreProtocol {
 
     func getSensorStatuses() -> [SahhaSensor: SahhaSensorStatus] {
         sensorStatuses
+    }
+
+    func dispose() {
+        storage.removeObject(forKey: key)
+        sensors = nil
+        sensorStatuses = [:]
     }
 }


### PR DESCRIPTION
## Summary

- `SensorStore` now conforms to the `Disposable` protocol
- Added `dispose()` method that removes persisted sensors from UserDefaults, nils out the in-memory sensor set, and resets sensor statuses to an empty dictionary
- Ensures sensor state is fully cleared on deauthentication

Closes #39