### PR TITLE
DeviceInfoSyncCache adopts Disposable — clear cache on deauth

### DIFF
--- a/Sources/Sahha/Features/DeviceInfoSync/Stores/DeviceInfoSyncCache.swift
+++ b/Sources/Sahha/Features/DeviceInfoSync/Stores/DeviceInfoSyncCache.swift
@@ -5,7 +5,7 @@ private struct CachedDeviceInfo: Codable {
     let lastSync: Date
 }
 
-actor DeviceInfoSyncCache: DeviceInfoSyncCacheProtocol {
+actor DeviceInfoSyncCache: DeviceInfoSyncCacheProtocol, Disposable {
     private let key: String
     private let storage: UserDefaultsStorageProtocol
     private let ttl: TimeInterval
@@ -30,6 +30,10 @@ actor DeviceInfoSyncCache: DeviceInfoSyncCacheProtocol {
             try storage.setObject(value, forKey: key)
         } catch {
         }
+    }
+
+    func dispose() {
+        storage.removeObject(forKey: key)
     }
 
     func needsSync(comparedTo deviceInfo: DeviceInfo) -> Bool {


### PR DESCRIPTION
## Summary

- `DeviceInfoSyncCache` now conforms to the `Disposable` protocol
- `dispose()` removes the `deviceInfo` key from UserDefaults via `storage.removeObject(forKey: key)`
- After deauthentication, the next session triggers a fresh device info sync instead of relying on stale cached data

Closes #40