### PR TITLE
DLQMigrator.reset() — clear migration flag on deauth

### DIFF
--- a/Sources/Sahha/Core/Upload/DLQMigrator.swift
+++ b/Sources/Sahha/Core/Upload/DLQMigrator.swift
@@ -14,6 +14,11 @@ import Foundation
 enum DLQMigrator {
     private static let migrationKey = "dlq_migration_v1_complete"
 
+    /// Removes the migration flag so the validation can re-run on the next session.
+    static func reset() {
+        UserDefaults.standard.removeObject(forKey: migrationKey)
+    }
+
     /// Run migration validation once. Safe to call multiple times — no-ops after first run.
     static func migrateIfNeeded(
         storage: UserDefaultsStorageProtocol

--- a/Sources/Sahha/SahhaActor.swift
+++ b/Sources/Sahha/SahhaActor.swift
@@ -175,6 +175,7 @@ actor SahhaActor {
         if let task = configurationTask { _ = try await task.value }
         let (container, settings) = try await requireConfig()
         await container.reset()
+        DLQMigrator.reset()
         try await configure(with: settings)
     }
 


### PR DESCRIPTION
## Summary

Closes #42

- Adds a static `reset()` method to `DLQMigrator` that removes the `dlq_migration_v1_complete` key from UserDefaults
- Calls `DLQMigrator.reset()` in `SahhaActor.deauthenticate()` alongside the existing `container.reset()` call

This ensures the migration flag is cleared on deauthentication so the migration validation can re-run cleanly on the next session (which will be a no-op since persistent queue files are also cleared).

## Test plan

- [ ] After `deauthenticate()`, verify `dlq_migration_v1_complete` is not present in UserDefaults
- [ ] After `deauthenticate()` followed by `authenticate()`, verify the SDK configures correctly and migration re-runs as a no-op